### PR TITLE
Fix comments for tenant_id

### DIFF
--- a/README.md
+++ b/README.md
@@ -367,7 +367,7 @@ Be aware that changing the correlation_id for a logger, will also affect ancesto
 In order to get the tenant_id of a request, you can use the following method:
 ```js
 app.get('/', function (req, res) {
-    // Get correlation_id from logger bound to request
+    // Get tenant_id from logger bound to request
     var tenantId = req.logger.getTenantId();
     
     res.send('Hello World');
@@ -377,7 +377,7 @@ app.get('/', function (req, res) {
 It is also possible to change the tenant_id to a value you like:
 ```js
 app.get('/', function (req, res) {
-    // Set correlation_id via logger bound to request
+    // Set tenant_id via logger bound to request
     req.logger.setTenantId("cbc2654f-1c35-45d0-96fc-f32efac20986");
     
     res.send('Hello World');


### PR DESCRIPTION
Hey everyone,

here is a small fix of the comments for the ``getTenantId`` and ``setTenantId`` functions.

BR Robert