### PR TITLE
Fix timing issue by adding global rollover check

### DIFF
--- a/cf-nodejs-logging-support-core/log-core.js
+++ b/cf-nodejs-logging-support-core/log-core.js
@@ -52,8 +52,7 @@ var convenientLevelFunctions = [];
 var defaultCustomEnabled = true;
 var cfCustomEnabled = false;
 
-var lastTimestamp = 0;
-
+var lastLow = 0;
 
 // Initializes the core logger, including setup of environment var defined settings
 var init = function () {
@@ -296,13 +295,15 @@ var initLog = function () {
     var now = new Date();
     logObject.written_at = now.toJSON();
 
-    var lower = process.hrtime()[1] % 1000000
-    var higher = now.getTime() * NS_PER_MS
+    var lower = process.hrtime()[1] % NS_PER_MS;
+    var higher = now.getTime() * NS_PER_MS;
 
     logObject.written_ts = higher + lower;
-    if(logObject.written_ts < lastTimestamp)
-        logObject.written_ts += 1000000;
-    lastTimestamp = logObject.written_ts;
+    //This reorders written_ts, if the new timestamp seems to be smaller
+    // due to different rollover times for process.hrtime and now.getTime
+    if(lower < lastLow)
+        logObject.written_ts += NS_PER_MS;
+    lastLow = lower;
     return logObject;
 };
 

--- a/cf-nodejs-logging-support-core/log-core.js
+++ b/cf-nodejs-logging-support-core/log-core.js
@@ -52,7 +52,7 @@ var convenientLevelFunctions = [];
 var defaultCustomEnabled = true;
 var cfCustomEnabled = false;
 
-var lastLow = 0;
+var lastTimestamp = 0;
 
 // Initializes the core logger, including setup of environment var defined settings
 var init = function () {
@@ -295,15 +295,15 @@ var initLog = function () {
     var now = new Date();
     logObject.written_at = now.toJSON();
 
-    var lower = process.hrtime()[1] % NS_PER_MS;
-    var higher = now.getTime() * NS_PER_MS;
+    var lower = process.hrtime()[1] % NS_PER_MS
+    var higher = now.getTime() * NS_PER_MS
 
     logObject.written_ts = higher + lower;
     //This reorders written_ts, if the new timestamp seems to be smaller
     // due to different rollover times for process.hrtime and now.getTime
-    if(lower < lastLow)
+    if(logObject.written_ts < lastTimestamp)
         logObject.written_ts += NS_PER_MS;
-    lastLow = lower;
+    lastTimestamp = logObject.written_ts;
     return logObject;
 };
 

--- a/cf-nodejs-logging-support-core/log-core.js
+++ b/cf-nodejs-logging-support-core/log-core.js
@@ -52,6 +52,8 @@ var convenientLevelFunctions = [];
 var defaultCustomEnabled = true;
 var cfCustomEnabled = false;
 
+var lastTimestamp = 0;
+
 
 // Initializes the core logger, including setup of environment var defined settings
 var init = function () {
@@ -292,9 +294,15 @@ var initLog = function () {
     var logObject = JSON.parse(initDummy);
 
     var now = new Date();
-
     logObject.written_at = now.toJSON();
-    logObject.written_ts = now.getTime() * NS_PER_MS + (process.hrtime()[1] % 1000000);
+
+    var lower = process.hrtime()[1] % 1000000
+    var higher = now.getTime() * NS_PER_MS
+
+    logObject.written_ts = higher + lower;
+    if(logObject.written_ts < lastTimestamp)
+        logObject.written_ts += 1000000;
+    lastTimestamp = logObject.written_ts;
     return logObject;
 };
 

--- a/test/test-core.js
+++ b/test/test-core.js
@@ -1067,14 +1067,17 @@ describe('Test log-core', function () {
             overrideCustomFieldFormat("default");
         })
 
-
-
         it('Test timings', function () {
-            log("info","test");
-            var time1 = logObject.written_ts;
-            log("info","test");
-            var time2 = logObject.written_ts;
-            assert.isTrue(time1 < time2);
+            var timing_runs = 10000
+            var count = 0;
+            for(var i = 0; i < timing_runs; i++){
+                log("info","test");
+                var time1 = logObject.written_ts;
+                log("info","test");
+                var time2 = logObject.written_ts;
+               count += time1 < time2 ? 1:0 ;
+            }
+            assert.equal(timing_runs, count);
         });
 
         it("Test simple log", function () {

--- a/test/test-core.js
+++ b/test/test-core.js
@@ -1040,6 +1040,91 @@ describe('Test log-core', function () {
         });
     });
 
+    describe('Test timings', function () {
+        var core = rewire("../cf-nodejs-logging-support-core/log-core.js");
+
+        var logObject = null;
+        var log = null;
+        var registerCustomFields = null;
+        var overrideCustomFieldFormat = null;
+        var setCustomFields = null;
+
+        before(function () {
+            core.__set__({
+                "sendLog": function (logObj) {
+                    logObject = logObj;
+                }
+            });
+            core.setConfig(importFresh("../config.js").config);
+
+            log = core.logMessage;
+            registerCustomFields = core.registerCustomFields;
+            setCustomFields = core.setCustomFields;
+            overrideCustomFieldFormat = core.overrideCustomFieldFormat;
+            process.hrtime = function (){
+                    return [this.hrHigh, this.hrLow];
+                }
+            process.setHrTime = function (high, low){
+                    this.hrHigh = high;
+                    this.hrLow = low;
+                }
+        });
+
+        beforeEach(function () {
+            core.__set__({
+                "lastLow": 0
+            })
+        });
+
+        it('Test normal', function () {
+            //tests behaviour for reasonable timestamps
+            process.setHrTime(1,1000);
+            log("info","test");
+            var time1 = logObject.written_ts;
+            process.setHrTime(1,2000);
+            log("info","test");
+            var time2 = logObject.written_ts;
+            assert.isBelow(time1,time2);
+        });
+
+        it('Test wrong', function () {
+            //testing for one wrong ordered ns timestamp
+            process.setHrTime(1,1000);
+            log("info","test");
+            var time1 = logObject.written_ts;
+            process.setHrTime(1,0);
+            log("info","test");
+            var time2 = logObject.written_ts;
+            assert.isBelow(time1,time2);
+        });
+
+        it('Test overflow', function () {
+            //testing hrtime overflow behaviour
+            process.setHrTime(1,999000);
+            log("info","test");
+            var time1 = logObject.written_ts;
+            process.setHrTime(1,1000000);
+            log("info","test");
+            var time2 = logObject.written_ts;
+            assert.isBelow(time1,time2);
+        });
+
+        it('Test small incremental', function () {
+            //small incremental may result in the same timestamp
+            //this makes sure that they are at least the same or correct
+            process.setHrTime(1,1001);
+            log("info","test");
+            var time1 = logObject.written_ts;
+            process.setHrTime(1,1002);
+            log("info","test");
+            var time2 = logObject.written_ts;
+            process.setHrTime(1,1003);
+            log("info","test");
+            var time3 = logObject.written_ts;
+            assert.isAtLeast(time3,time2);
+        });
+    })
+
     describe('Test logMessage', function () {
         var core = rewire("../cf-nodejs-logging-support-core/log-core.js");
 
@@ -1067,18 +1152,6 @@ describe('Test log-core', function () {
             overrideCustomFieldFormat("default");
         })
 
-        it('Test timings', function () {
-            var timing_runs = 10000
-            var count = 0;
-            for(var i = 0; i < timing_runs; i++){
-                log("info","test");
-                var time1 = logObject.written_ts;
-                log("info","test");
-                var time2 = logObject.written_ts;
-               count += time1 < time2 ? 1:0 ;
-            }
-            assert.equal(timing_runs, count);
-        });
 
         it("Test simple log", function () {
             log("info", "Test");

--- a/test/test-core.js
+++ b/test/test-core.js
@@ -1087,17 +1087,6 @@ describe('Test log-core', function () {
             assert.isBelow(time1,time2);
         });
 
-        it('Test wrong', function () {
-            //testing for one wrong ordered ns timestamp
-            process.setHrTime(1,1000);
-            log("info","test");
-            var time1 = logObject.written_ts;
-            process.setHrTime(1,0);
-            log("info","test");
-            var time2 = logObject.written_ts;
-            assert.isBelow(time1,time2);
-        });
-
         it('Test overflow', function () {
             //testing hrtime overflow behaviour
             process.setHrTime(1,999000);


### PR DESCRIPTION
This change fixes the possibility of timestamps not beeing in the correct order due to asynchronous
rollover times for process.hrtime() and Date.now().
This lead to timestamps sometimes beeing reported in the wrong order.