### PR TITLE
Decalring "defaultConfig" using var in index.js

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ var effectiveLogger = null;
 coreLogger.init();
 
 effectiveLogger = require("./logger/log-express");
-defaultConfig = require("./config");
+var defaultConfig = require("./config");
 effectiveLogger.setCoreLogger(coreLogger);
 
 coreLogger.setConfig(defaultConfig.config);


### PR DESCRIPTION
The defaultConfig varaiable was not declared using "var" so the library was breaking in when used in strict mode. 
Thank you for considering my PR.