### PR TITLE
Add support for HTTP proxy and ssl headers

### DIFF
--- a/config.js
+++ b/config.js
@@ -175,7 +175,7 @@ var config = [
     }, {
         name: "remote_host",
         mandatory: true,
-        envVarSwitch: "LOG_SENSITIVE_CONNECTION_DATA",
+        envVarRedact: "LOG_SENSITIVE_CONNECTION_DATA",
         source: {
             type: "special"
         },
@@ -185,7 +185,7 @@ var config = [
     }, {
         name: "remote_port",
         mandatory: true,
-        envVarSwitch: "LOG_SENSITIVE_CONNECTION_DATA",
+        envVarRedact : "LOG_SENSITIVE_CONNECTION_DATA",
         source: {
             type: "special"
         },
@@ -195,7 +195,7 @@ var config = [
     }, {
         name: "remote_user",
         mandatory: true,
-        envVarSwitch: "LOG_REMOTE_USER",
+        envVarRedact: "LOG_REMOTE_USER",
         source: {
             type: "header",
             name: "remote-user"
@@ -209,18 +209,9 @@ var config = [
             value: "IN"
         }
     }, {
-        name: "x_forwarded_for",
-        mandatory: true,
-        envVarSwitch: "LOG_SENSITIVE_CONNECTION_DATA",
-        source: {
-            type: "header",
-            name: "x-forwarded-for"
-        },
-        default: ""
-    }, {
         name: "remote_ip",
         mandatory: false,
-        envVarSwitch: "LOG_SENSITIVE_CONNECTION_DATA",
+        envVarRedact: "LOG_SENSITIVE_CONNECTION_DATA",
         source: {
             type: "self",
             name: "remote_host"
@@ -265,7 +256,7 @@ var config = [
     }, {
         name: "referer",
         mandatory: true,
-        envVarSwitch: "LOG_REFERER",
+        envVarRedact: "LOG_REFERER",
         source: {
             type: "header",
             name: "referer"
@@ -294,6 +285,15 @@ var config = [
         mandatory: true,
         source: {
             type: "static",
+        },
+        default: "-"
+    }, {
+        name: "x_forwarded_for",
+        mandatory: true,
+        envVarRedact: "LOG_SENSITIVE_CONNECTION_DATA",
+        source: {
+            type: "header",
+            name: "x-forwarded-for"
         },
         default: "-"
     }

--- a/config.js
+++ b/config.js
@@ -1,5 +1,41 @@
 var uuid = require("uuid/v4");
 
+
+/* FIELD CONFIGURATION 
+ *  
+ * Config description:
+ * 
+ * name:            The name of the field in log output
+ * mandatory:       If true: Use default value OR fallback function result if value is null. If false: omit field, if value is null.
+ * core: If true:   Add field also to message logs
+ * envVarRedact:    If set: 
+ *                      Only log this field, if specified environment variable is set to "true". 
+ *                      If specified environment variable is not set to "true" or not present, field gets omitted. This is also affects 
+ *                      fields marked as mandatory.
+ * envVarRedact:    If set: 
+ *                      Only log this field, if specified environment variable is set to "true". 
+ *                      If specified environment variable is not set to "true" or not present, field gets set to "redacted" if it is not 
+ *                      set to its default value or null.
+ * source:          Source of the field value.
+ *   type:          One of
+ *                     "static": use value from value field.
+ *                     "env": read value from environment variable.
+ *                     "nested-env": read value from environment variable with json object. Select variable and field by specifying a path.
+ *                     "self": copy value from another configured field.
+ *                     "header": read value from request/response header.
+ *                     "field": read value from request/response object.
+ *                     "time": intended to be used for time/duration calculations.
+ *                          calls method pre(req, res, logObject) when a request arrives. The log field gets set to the returned value.
+ *                          calls method post(req, res, logObject) when the response got sent. The log field gets set to the returned value.
+ *                     "special": calls the fallback(req, res, logObject) directly and sets the log field to the returned value.
+ *   name:          Name for "env", "self", "header" and "field" sources.
+ *   path:          Path for "nested-env" source.
+ *   value:         Value for "static" source.
+ *   parent:        Parent for "header" and "field" source: Can be "req" to access the request and "res" to access the response.
+ *   pre:           Define a pre(req, res, logObject) function for time source.
+ *   post:          Define a post(req, res, logObject) function for time source.
+ */
+
 var config = [
     {
         name: "component_type",
@@ -289,11 +325,106 @@ var config = [
         default: "-"
     }, {
         name: "x_forwarded_for",
-        mandatory: true,
+        mandatory: false,
         envVarRedact: "LOG_SENSITIVE_CONNECTION_DATA",
         source: {
             type: "header",
             name: "x-forwarded-for"
+        }
+    }, {
+        name: "x_custom_host",
+        mandatory: false,
+        envVarRedact: "LOG_SENSITIVE_CONNECTION_DATA",
+        source: {
+            type: "header",
+            name: "x-custom-host"
+        }
+    }, {
+        name: "x_forwarded_host",
+        mandatory: false,
+        envVarRedact: "LOG_SENSITIVE_CONNECTION_DATA",
+        source: {
+            type: "header",
+            name: "x-forwarded-host"
+        }
+    }, {
+        name: "x_forwarded_proto",
+        mandatory: false,
+        envVarRedact: "LOG_SENSITIVE_CONNECTION_DATA",
+        source: {
+            type: "header",
+            name: "x-forwarded-proto"
+        }
+    }, {
+        name: "x_ssl_client",
+        mandatory: true,
+        envVarSwitch: "LOG_SSL_HEADERS",
+        source: {
+            type: "header",
+            name: "x-ssl-client"
+        },
+        default: "-"
+    }, {
+        name: "x_ssl_client_verify",
+        mandatory: true,
+        envVarSwitch: "LOG_SSL_HEADERS",
+        source: {
+            type: "header",
+            name: "x-ssl-client-verify"
+        },
+        default: "-"
+    }, {
+        name: "x_ssl_client_subject_dn",
+        mandatory: true,
+        envVarSwitch: "LOG_SSL_HEADERS",
+        source: {
+            type: "header",
+            name: "x-ssl-client-subject-dn"
+        },
+        default: "-"
+    }, {
+        name: "x_ssl_client_subject_cn",
+        mandatory: true,
+        envVarSwitch: "LOG_SSL_HEADERS",
+        source: {
+            type: "header",
+            name: "x-ssl-client-subject-cn"
+        },
+        default: "-"
+    }, {
+        name: "x_ssl_client_issuer_dn",
+        mandatory: true,
+        envVarSwitch: "LOG_SSL_HEADERS",
+        source: {
+            type: "header",
+            name: "x-ssl-client-issuer-dn"
+        },
+        default: "-"
+    }, {
+        name: "x_ssl_client_notbefore",
+        mandatory: true,
+        envVarSwitch: "LOG_SSL_HEADERS",
+        source: {
+            type: "header",
+            name: "x-ssl-client-notbefore"
+        },
+        default: "-"
+    }, {
+        name: "x_ssl_client_notafter",
+        mandatory: true,
+        envVarSwitch: "LOG_SSL_HEADERS",
+        source: {
+            type: "header",
+            name: "x-ssl-client-notafter"
+        },
+        default: "-"
+    }, {
+        name: "x_ssl_client_session_id",
+        mandatory: true,
+        envVarSwitch: "LOG_SSL_HEADERS",
+        source: {
+            type: "header",
+            name: "x-ssl-client-session-id"
         },
         default: "-"
     }

--- a/config.js
+++ b/config.js
@@ -28,7 +28,7 @@ var uuid = require("uuid/v4");
  *                          calls method pre(req, res, logObject) when a request arrives. The log field gets set to the returned value.
  *                          calls method post(req, res, logObject) when the response got sent. The log field gets set to the returned value.
  *                     "special": calls the fallback(req, res, logObject) directly and sets the log field to the returned value.
- *   name:          Name for "env", "self", "header" and "field" sources.
+ *   name:          Key name for "env", "self", "header" and "field" sources.
  *   path:          Path for "nested-env" source.
  *   value:         Value for "static" source.
  *   parent:        Parent for "header" and "field" source: Can be "req" to access the request and "res" to access the response.

--- a/core/log-core.js
+++ b/core/log-core.js
@@ -115,7 +115,7 @@ var setConfig = function (config) {
 };
 
 
-// Seperate core configuration (processed once, included in network and message logs) and
+// Separate core configuration (processed once, included in network and message logs) and
 // pre and post configuration (processed before and after request handling)
 var precompileConfig = function (config) {
     var coreConfig = [];
@@ -127,9 +127,18 @@ var precompileConfig = function (config) {
     for (var i = 0; i < config.length; i++) {
         var obj = config[i];
 
-        // Check if config field needs a set env var to be enabled. If specified env var does not exist, the resulting log field will be replaced by REDUCED_PLACEHOLDER
+        // Check if config field needs a set env var to be enabled. If specified env var does not exist the log field gets omitted. 
         if (obj.envVarSwitch != null) {
             var val = process.env[obj.envVarSwitch];
+            var pass = (val == "true" || val == "True" || val == "TRUE");
+            if (!pass) {
+                continue; 
+            }
+        }
+
+        // Check if config field needs a set env var to be written as is. If specified env var does not exist the resulting log field will set to REDUCED_PLACEHOLDER.
+        if (obj.envVarRedact != null) {
+            var val = process.env[obj.envVarRedact];
             var pass = (val == "true" || val == "True" || val == "TRUE");
             if (!pass) {
                 obj.reduce = true;
@@ -416,7 +425,7 @@ var setLogPattern = function (p) {
 // Simple
 // logMessage("info", "Hello World"); >> ... "msg":"Hello World" ...
 //
-// With addtional numeric value
+// With additional numeric value
 // logMessage("info", "Listening on port %d", 5000); >> ... "msg":"Listening on port 5000" ...
 //
 // With additional string values

--- a/docs/advanced-usage/03-sensitive-data-reduction.md
+++ b/docs/advanced-usage/03-sensitive-data-reduction.md
@@ -7,18 +7,40 @@ permalink: /advanced-usage/sensitive-data-redaction
 ---
 
 # Sensitive data redaction
-Version 3.0.0 and above implement a sensitive data redaction system which disables logging of sensitive fields. 
-These fields will contain 'redacted' instead of the original content.
 
-Following fields are *redacted* by default: `remote_ip`, `remote_host`, `remote_port`, `x_forwarded_for`, `remote_user` and `referer`.
+Version 3.0.0 and above implement a sensitive data redaction system which disables logging of sensitive fields.
+These fields will contain 'redacted' instead of the original content or are omitted.
+
+Following fields are *redacted* by default:
+
+- `remote_ip`
+- `remote_host`
+- `remote_port`
+- `x_forwarded_for`
+- `x_forwarded_host`
+- `x_forwarded_proto`
+- `x_custom_host`
+- `remote_user`
+- `referer`
+
+Following fields are *omitted* by default:
+
+- `x_ssl_client`
+- `x_ssl_client_verify`
+- `x_ssl_client_subject_dn`
+- `x_ssl_client_subject_cn`
+- `x_ssl_client_issuer_dn`
+- `x_ssl_client_notbefore`
+- `x_ssl_client_notafter`
+- `x_ssl_client_session_id`
 
 In order to activate usual logging for all or some of these fields you have to set specific environment variables:
 
-| Environment Variable                      | Optional fields                                                           |
-|-------------------------------------------|---------------------------------------------------------------------------|
-| ```LOG_SENSITIVE_CONNECTION_DATA: true``` | activates the fields remote_ip, remote_host, remote_port, x_forwarded_for |
-| ```LOG_REMOTE_USER: true```               | activates the field remote_user                                           |
-| ```LOG_REFERER: true```                   | activates the field referer                                               |
-
+| Environment Variable                      | Optional fields                                                                                      |
+|-------------------------------------------|------------------------------------------------------------------------------------------------------|
+| ```LOG_SENSITIVE_CONNECTION_DATA: true``` | activates the fields `remote_ip`, `remote_host`, `remote_port`, `x_forwarded_*` and `x_custom_host`  |
+| ```LOG_REMOTE_USER: true```               | activates the field `remote_user`                                                                    |
+| ```LOG_REFERER: true```                   | activates the field `referer`                                                                        |
+| ```LOG_SSL_HEADERS: true```               | activates the ssl header fields `x_ssl_*`                                                            |
 
 This behavior matches with the corresponding mechanism in the [CF Java Logging Support](https://github.com/SAP/cf-java-logging-support/wiki/Overview#logging-sensitive-user-data) library.

--- a/logger/log-connect.js
+++ b/logger/log-connect.js
@@ -11,7 +11,7 @@ var logNetwork = function (req, res, next) {
 
     var logObject = core.initRequestLog();
 
-    //rendering the given arguments failsave against missing fields
+    //rendering the given arguments failsafe against missing fields
     if (req.connection == null) {
         req.connection = {};
     }

--- a/logger/log-express.js
+++ b/logger/log-express.js
@@ -11,7 +11,7 @@ var logNetwork = function (req, res, next) {
 
     var logObject = core.initRequestLog();
 
-    //rendering the given arguments failsave against missing fields
+    //rendering the given arguments failsafe against missing fields
     if (typeof req.header != "function") {
         req.header = function () {
             return "";

--- a/logger/log-plainhttp.js
+++ b/logger/log-plainhttp.js
@@ -12,7 +12,7 @@ var logNetwork = function (req, res) {
 
     var logObject = core.initRequestLog();
 
-    //rendering the given arguments failsave against missing fields
+    //rendering the given arguments failsafe against missing fields
     if (req.connection == null) {
         req.connection = {};
     }

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   "author": {
     "name": "Christian Dinse, Nicklas Dohrn"
   },
+  "homepage": "https://sap.github.io/cf-nodejs-logging-support/",
   "main": "./index.js",
   "engines": {
     "node": ">=8.0.0"

--- a/test/allbranchconfig.js
+++ b/test/allbranchconfig.js
@@ -2,311 +2,122 @@ var uuid = require("uuid/v4");
 
 var config = [
     {
-        name: "component_type",
+        name: "test_static",
         mandatory: true,
-        core: true,
         source: {
             type: "static",
-            value: "application"
+            value: "test-value-static"
         }
-    }, {
-        name: "component_id",
+    },
+    {
+        name: "test_header_req",
         mandatory: true,
-        core: true,
         source: {
-            type: "nested-env",
-            path: ["VCAP_APPLICATION", "application_id"]
+            type: "header",
+            name: "test-header-req"
         },
         default: "-"
-    }, {
-        name: "component_name",
+    },
+    {
+        name: "test_header_res",
         mandatory: true,
-        core: true,
         source: {
-            type: "nested-env",
-            path: ["VCAP_APPLICATION", "application_name"]
+            type: "header",
+            name: "test-header-res",
+            parent: "res"
         },
         default: "-"
-    }, {
-        name: "component_instance",
+    },
+    {
+        name: "test_self_req",
         mandatory: true,
-        core: true,
-        source: {
-            type: "nested-env",
-            path: ["VCAP_APPLICATION", "instance_index"]
-        },
-        default: "0"
-    }, {
-        name: "source_instance",
-        mandatory: false,
-        core: true,
         source: {
             type: "self",
-            name: "component_instance"
-        }
-    }, {
-        name: "layer",
-        mandatory: true,
-        core: true,
-        source: {
-            type: "static",
-            value: "[NODEJS]"
-        }
-    }, {
-        name: "organization_id",
-        mandatory: true,
-        core: true,
-        source: {
-            type: "static",
-            value: "-"
-        }
-    }, {
-        name: "organization_name",
-        mandatory: true,
-        core: true,
-        source: {
-            type: "static",
-            value: "-"
-        }
-    }, {
-        name: "space_name",
-        mandatory: true,
-        core: true,
-        source: {
-            type: "nested-env",
-            path: ["VCAP_APPLICATION", "space_name"]
+            name: "test_header_req"
         },
         default: "-"
-    }, {
-        name: "space_id",
+    },
+    {
+        name: "test_self_res",
         mandatory: true,
-        core: true,
         source: {
-            type: "nested-env",
-            path: ["VCAP_APPLICATION", "space_id"]
+            type: "self",
+            name: "test_header_res",
+            parent: "res"
         },
         default: "-"
-    }, {
-        name: "container_id",
-        mandatory: true,
-        core: true,
-        source: {
-            type: "env",
-            name: "CF_INSTANCE_IP"
-        },
-        default: "-"
-    }, {
-        name: "logger",
-        mandatory: true,
-        core: true,
-        source: {
-            type: "static",
-            value: "nodejs-logger"
-        }
-    }, {
-        name: "request_id",
-        mandatory: true,
-        source: {
-            type: "header",
-            name: "x-vcap-request-id"
-        },
-        default: "-"
-    }, {
-        name: "request_size_b",
-        mandatory: true,
-        source: {
-            type: "header",
-            name: "content-length"
-        },
-        default: -1
-    }, {
-        name: "type",
-        mandatory: true,
-        source: {
-            type: "static",
-            value: "request"
-        }
-    }, {
-        name: "request",
+    },
+    {
+        name: "test_field_req",
         mandatory: true,
         source: {
             type: "field",
-            name: "url"
+            name: "test-field"
         },
         default: "-"
-    }, {
-        name: "response_status",
+    },
+    {
+        name: "test_field_res",
         mandatory: true,
         source: {
             type: "field",
-            parent: "res",
-            name: "statusCode"
-        },
-        default: 200
-    }, {
-        name: "method",
-        mandatory: true,
-        source: {
-            type: "field",
-            name: "method"
+            name: "test-field",
+            parent: "res"
         },
         default: "-"
-    }, {
-        name: "response_size_b",
-        mandatory: true,
-        source: {
-            type: "header",
-            parent: "res",
-            name: "content-length"
-        },
-        default: -1
-    }, {
-        name: "response_content_type",
-        mandatory: true,
-        source: {
-            type: "header",
-            parent: "res",
-            name: "content-type"
-        },
-        default: "-"
-
-    }, {
-        name: "remote_host",
-        mandatory: true,
-        envVarSwitch: "LOG_SENSITIVE_CONNECTION_DATA",
-        source: {
-            type: "special"
-        },
-        fallback: (req, res, logObj) => {
-            return req.connection.remoteAddress == null ? "-" : req.connection.remoteAddress;
-        }
-    }, {
-        name: "remote_port",
-        mandatory: true,
-        envVarSwitch: "LOG_SENSITIVE_CONNECTION_DATA",
-        source: {
-            type: "special"
-        },
-        fallback: (req, res, logObj) => {
-            return req.connection.remotePort == null ? "-" : req.connection.remotePort.toString();
-        }
-    }, {
-        name: "remote_user",
-        mandatory: true,
-        envVarSwitch: "LOG_REMOTE_USER",
-        source: {
-            type: "static",
-            value: "-"
-        }
-    }, {
-        name: "direction",
-        mandatory: true,
-        source: {
-            type: "static",
-            value: "IN"
-        }
-    }, {
-        name: "x_forwarded_for",
-        mandatory: true,
-        envVarSwitch: "LOG_SENSITIVE_CONNECTION_DATA",
-        source: {
-            type: "special"
-        },
-        fallback: (req, res, logObj) => {
-            return req.headers['x-forwarded-for'] == null ? "" : req.headers['x-forwarded-for'];
-        }
-    }, {
-        name: "remote_ip",
-        mandatory: false,
-        envVarSwitch: "LOG_SENSITIVE_CONNECTION_DATA",
-        source: {
-            type: "self",
-            name: "remote_host"
-        }
-    }, {
-        name: "request_received_at",
-        mandatory: false,
-        source: {
-            type: "self",
-            name: "written_at"
-        }
-    }, {
-        name: "protocol",
-        mandatory: true,
-        source: {
-            type: "special"
-        },
-        fallback: (req, res, logObj) => {
-            return "HTTP" + (req.httpVersion == null ? "" : "/" + req.httpVersion);
-        }
-    }, {
-        name: "response_time_ms",
+    },
+    {
+        name: "test_time",
         mandatory: true,
         source: {
             type: "time",
-            pre: () => {
-                return Date.now();
+            pre: (req, res, logObj) => {
+                return 1;
             },
             post: (req, res, logObj) => {
-                return Date.now() - logObj.response_time_ms;
+                return 2 + logObj.test_time;
             }
         }
-    }, {
-        name: "response_sent_at",
+    },
+    {
+        name: "test_special_req",
         mandatory: true,
         source: {
-            type: "time",
-            post: (req, res, logObj) => {
-                return (new Date()).toJSON();
-            }
-        }
-    }, {
-        name: "referer",
-        mandatory: true,
-        envVarSwitch: "LOG_REFERER",
-        source: {
-            type: "header",
-            name: "referer"
-        },
-        default: "-"
-    }, {
-        name: "correlation_id",
-        mandatory: true,
-        source: {
-            type: "header",
-            name: "X-CorrelationID"
-        },
-        fallback: (req, res, logObject) => {
-            return uuid();
-        }
-    }, {
-        name: "tenant_id",
-        mandatory: true,
-        source: {
-            type: "header",
-            name: "tenantid"
-        },
-        default: "-"
-    }, {
-        name: "testSpecialPost",
-        mandatory: true,
-        source:{
-            type: "special",
-            parent: "res",
+            type: "special"
         },
         fallback: (req, res, logObj) => {
-            return "res special fallback";
+            return "test-value-special-req";
         }
-    }, {
-        name: "testSelfPost",
+    },
+    {
+        name: "test_special_res",
         mandatory: true,
-        source:{
-            type: "self",
-            parent: "res",
-            name: "testSpecialPost"
+        source: {
+            type: "special",
+            parent: "res"
         },
-        default: "no reference possible"
-    }
+        fallback: (req, res, logObj) => {
+            return "test-value-special-res";
+        }
+    },
+    {
+        name: "test_defaults_req",
+        mandatory: true,
+        source: {
+            type: "field",
+            name: "not-existing-field",
+        },
+        default: "test-default-req"
+    },
+    {
+        name: "test_defaults_res",
+        mandatory: true,
+        source: {
+            type: "field",
+            name: "not-existing-field",
+        },
+        default: "test-default-res"
+    },
 ];
 
 

--- a/test/exp-results.js
+++ b/test/exp-results.js
@@ -30,7 +30,6 @@ exports.getLogMessage = function () {
         "remote_host": "-",
         "remote_port": "-",
         "remote_user": "test-user",
-        "x_forwarded_for": "",
         "protocol": "HTTP",
         "remote_ip": "-",
         "response_content_type": "-",
@@ -39,7 +38,19 @@ exports.getLogMessage = function () {
         "direction": "IN",
         "response_sent_at": "2017-01-01T00:00:00.000Z",
         "msg": "testmessage",
-        "level": "info"
+        "level": "info",
+        "x_custom_host": "host-3",
+        "x_forwarded_for": "host-1",
+        "x_forwarded_host": "host-2",
+        "x_forwarded_proto": "https",
+        "x_ssl_client": "-",
+        "x_ssl_client_issuer_dn": "-",
+        "x_ssl_client_notafter": "-",
+        "x_ssl_client_notbefore": "-",
+        "x_ssl_client_session_id": "-",
+        "x_ssl_client_subject_cn": "-",
+        "x_ssl_client_subject_dn": "-",
+        "x_ssl_client_verify": "-"
     };
     return message;
 

--- a/test/test-complete.js
+++ b/test/test-complete.js
@@ -21,6 +21,7 @@ describe('Test Complete', function () {
     process.env.LOG_SENSITIVE_CONNECTION_DATA = true;
     process.env.LOG_REMOTE_USER = true;
     process.env.LOG_REFERER = true;
+    process.env.LOG_SSL_HEADERS = true;
 
     process.env.VCAP_APPLICATION = JSON.stringify({
         application_id: "test-app-id",
@@ -68,8 +69,12 @@ describe('Test Complete', function () {
     it("checking dummy app results", () => {
         req = httpMock.createRequest({
             headers: {
-                "X-CorrelationID": "test-correlation-id",
-                "remote-user": "test-user"
+                "x-correlationid": "test-correlation-id",
+                "remote-user": "test-user",
+                "x-forwarded-for": "host-1",
+                "x-forwarded-host": "host-2",
+                "x-forwarded-proto": "https",
+                "x-custom-host": "host-3"
             }
         });
         res = httpMock.createResponse();

--- a/test/test-config.js
+++ b/test/test-config.js
@@ -15,6 +15,7 @@ describe('Test config', function () {
         process.env.LOG_SENSITIVE_CONNECTION_DATA = true;
         process.env.LOG_REMOTE_USER = true;
         process.env.LOG_REFERER = true;
+        process.env.LOG_SSL_HEADERS = true;
 
         core = importFresh("../core/log-core.js");
         httpLogger = importFresh("../logger/log-plainhttp.js");
@@ -71,33 +72,133 @@ describe('Test config', function () {
 
         it('Test x_forwarded_for', function () {
             req.headers = {};
-            req.headers['x-forwarded-for'] = "testingHeader";
+            req.headers['x-forwarded-for'] = "test-host";
             httpLogger.logNetwork(req, res, next);
             fireLog();
 
-            logObject.x_forwarded_for.should.equal("testingHeader");
+            logObject.x_forwarded_for.should.equal("test-host");
+        });
+
+        it('Test x_custom_host', function () {
+            req.headers = {};
+            req.headers['x-custom-host'] = "test-host";
+            httpLogger.logNetwork(req, res, next);
+            fireLog();
+
+            logObject.x_custom_host.should.equal("test-host");
+        });
+
+        it('Test x_forwarded_host', function () {
+            req.headers = {};
+            req.headers['x-forwarded-host'] = "test-host";
+            httpLogger.logNetwork(req, res, next);
+            fireLog();
+
+            logObject.x_forwarded_host.should.equal("test-host");
+        });
+
+        it('Test x_forwarded_proto', function () {
+            req.headers = {};
+            req.headers['x-forwarded-proto'] = "https";
+            httpLogger.logNetwork(req, res, next);
+            fireLog();
+
+            logObject.x_forwarded_proto.should.equal("https");
+        });
+
+
+        it('Test x_ssl_client', function () {
+            req.headers = {};
+            req.headers['x-ssl-client'] = "0";
+            httpLogger.logNetwork(req, res, next);
+            fireLog();
+
+            logObject.x_ssl_client.should.equal("0");
+        });
+
+        it('Test x_ssl_client_verify', function () {
+            req.headers = {};
+            req.headers['x-ssl-client-verify'] = "0";
+            httpLogger.logNetwork(req, res, next);
+            fireLog();
+
+            logObject.x_ssl_client_verify.should.equal("0");
+        });
+
+        it('Test x_ssl_client_subject_dn', function () {
+            req.headers = {};
+            req.headers['x-ssl-client-subject-dn'] = "/C=FR/ST=Ile de France/L=Jouy en Josas/O=haproxy.com/CN=client1/emailAddress=ba@haproxy.com";
+            httpLogger.logNetwork(req, res, next);
+            fireLog();
+
+            logObject.x_ssl_client_subject_dn.should.equal("/C=FR/ST=Ile de France/L=Jouy en Josas/O=haproxy.com/CN=client1/emailAddress=ba@haproxy.com");
+        });
+
+        it('Test x_ssl_client_subject_cn', function () {
+            req.headers = {};
+            req.headers['x-ssl-client-subject-cn'] = "client1";
+            httpLogger.logNetwork(req, res, next);
+            fireLog();
+
+            logObject.x_ssl_client_subject_cn.should.equal("client1");
+        });
+
+        it('Test x_ssl_client_issuer_dn', function () {
+            req.headers = {};
+            req.headers['x-ssl-client-issuer-dn'] = "/C=FR/ST=Ile de France/L=Jouy en Josas/O=haproxy.com/CN=haproxy.com/emailAddress=ba@haproxy.com";
+            httpLogger.logNetwork(req, res, next);
+            fireLog();
+
+            logObject.x_ssl_client_issuer_dn.should.equal("/C=FR/ST=Ile de France/L=Jouy en Josas/O=haproxy.com/CN=haproxy.com/emailAddress=ba@haproxy.com");
+        });
+
+        it('Test x_ssl_client_notbefore', function () {
+            req.headers = {};
+            req.headers['x-ssl-client-notbefore'] = "130613144555Z";
+            httpLogger.logNetwork(req, res, next);
+            fireLog();
+
+            logObject.x_ssl_client_notbefore.should.equal("130613144555Z");
+        });
+
+        it('Test x_ssl_client_notafter', function () {
+            req.headers = {};
+            req.headers['x-ssl-client-notafter'] = "140613144555Z";
+            httpLogger.logNetwork(req, res, next);
+            fireLog();
+
+            logObject.x_ssl_client_notafter.should.equal("140613144555Z");
+        });
+
+        it('Test x_ssl_client_session_id', function () {
+            req.headers = {};
+            req.headers['x-ssl-client-session-id'] = "test-id";
+            httpLogger.logNetwork(req, res, next);
+            fireLog();
+
+            logObject.x_ssl_client_session_id.should.equal("test-id");
         });
 
         it('Test sap_passport', function () {
             var config = index.enableTracing("sap_passport")
             core.setConfig(config);
             req.headers = {};
-            req.headers['sap-passport'] = "testingHeader";
+            req.headers['sap-passport'] = "test-header";
             httpLogger.logNetwork(req, res, next);
             fireLog();
 
-            logObject.sap_passport.should.equal("testingHeader");
+            logObject.sap_passport.should.equal("test-header");
         });
 
         it('Test sap_passport with array', function () {
             var config = index.enableTracing(["SAP_passport"]);
             core.setConfig(config);
             req.headers = {};
-            req.headers['sap-passport'] = "testingHeader";
+            req.headers['sap-passport'] = "test-header";
             httpLogger.logNetwork(req, res, next);
             fireLog();
 
-            logObject.sap_passport.should.equal("testingHeader");
+            logObject.sap_passport.should.equal("test-header");
         });
 
         it('Test remote_user', function () {
@@ -150,10 +251,8 @@ describe('Test config', function () {
             logObject.response_size_b.should.equal(-1);
             logObject.response_content_type.should.equal("-");
             logObject.remote_port.should.equal("-");
-            logObject.x_forwarded_for.should.equal("");
             logObject.protocol.should.equal("HTTP");
             logObject.response_content_type.should.equal("-");
-
         });
 
 

--- a/test/test-core.js
+++ b/test/test-core.js
@@ -70,7 +70,7 @@ describe('Test log-core', function () {
             };
         })
 
-        it('Test correct handling of cases: ', function () {
+        it('Test correct handling of cases', function () {
             reduceFields(testConfig, logObj);
             logObj["test-field-a"].should.not.equal(42);
             logObj["test-field-b"].should.equal("test");
@@ -189,7 +189,7 @@ describe('Test log-core', function () {
             log = core.logMessage;
         });
 
-        it('Test config assignment (settable): ', function () {
+        it('Test config assignment (settable)', function () {
             log("info","test", {"settable_field":"settable","non_settable":"test"})
             
             logObject.settable_field.should.equal("settable");
@@ -197,7 +197,7 @@ describe('Test log-core', function () {
             
         });
 
-        it('Test settable propagation: ', function () {
+        it('Test settable propagation', function () {
 
             core.__set__({
                 "prepareInitDummy": function (config) {
@@ -249,7 +249,7 @@ describe('Test log-core', function () {
             core = rewire("../core/log-core.js");
         });
 
-        it('Test config assignment (core): ', function () {
+        it('Test config assignment (core)', function () {
 
             core.__set__({
                 "prepareInitDummy": function (config) {
@@ -261,7 +261,7 @@ describe('Test log-core', function () {
             core.setConfig(testConfig);
         });
 
-        it('Test config assignment (pre): ', function () {
+        it('Test config assignment (pre)', function () {
             core.setConfig(testConfig);
 
             var config = core.getPreLogConfig();
@@ -270,7 +270,7 @@ describe('Test log-core', function () {
             config[1].should.equal(testConfig[2]);
         });
 
-        it('Test config assignment (post): ', function () {
+        it('Test config assignment (post)', function () {
             core.setConfig(testConfig);
 
             var config = core.getPostLogConfig();
@@ -305,7 +305,7 @@ describe('Test log-core', function () {
             core = rewire("../core/log-core.js");
         });
 
-        it('Test config assignment (core): ', function () {
+        it('Test config assignment (core)', function () {
 
             core.__set__({
                 "prepareInitDummy": function (config) {
@@ -501,7 +501,7 @@ describe('Test log-core', function () {
             core.setConfig(importFresh("../config.js").config);
         });
 
-        it('Test equals method: ', function () {
+        it('Test equals method', function () {
             core.isValidObject(null).should.equal(false);
             core.isValidObject(undefined).should.equal(false);
             core.isValidObject({}).should.equal(false);
@@ -514,7 +514,7 @@ describe('Test log-core', function () {
             }).should.equal(true);
         });
 
-        it('Test for cyclic errors: ', function () {
+        it('Test for cyclic errors', function () {
             //cyclic obj test
             var a = {};
             var b = {};
@@ -1845,7 +1845,7 @@ describe('Test log-core', function () {
             clock.restore();
         });
 
-        it('Test written_at: ', function () {
+        it('Test written_at', function () {
             logObject = core.initLog();
             logObject.written_at.should.equal((new Date()).toJSON());
 
@@ -1854,59 +1854,59 @@ describe('Test log-core', function () {
             logObject.written_at.should.not.equal((new Date()).toJSON());
         });
 
-        it('Test written_ts: ', function () {
+        it('Test written_ts', function () {
             logObject = core.initLog();
             logObject.written_ts.should.equal((new Date()).getTime() * 1e6);
         });
 
         // Write values from process.env.VCAP_APPLICATION
-        it('Test component_id: ', function () {
+        it('Test component_id', function () {
             logObject = core.initLog();
             logObject.component_id.should.equal("123456");
         });
 
-        it('Test component_name: ', function () {
+        it('Test component_name', function () {
             logObject = core.initLog();
             logObject.component_name.should.equal("test_app_name");
         });
 
-        it('Test component_instance: ', function () {
+        it('Test component_instance', function () {
             logObject = core.initLog();
             logObject.component_instance.should.equal("43");
         });
 
-        it('Test space_name: ', function () {
+        it('Test space_name', function () {
             logObject = core.initLog();
             logObject.space_name.should.equal("test_space_name");
         });
 
-        it('Test space_id: ', function () {
+        it('Test space_id', function () {
             logObject = core.initLog();
             logObject.space_id.should.equal("234567");
         });
 
-        it('Test organization_name: ', function () {
+        it('Test organization_name', function () {
             logObject = core.initLog();
             logObject.organization_name.should.equal("test_org_name");
         });
 
-        it('Test organization_id: ', function () {
+        it('Test organization_id', function () {
             logObject = core.initLog();
             logObject.organization_id.should.equal("345678");
         });
 
-        it('Test source_instance: ', function () {
+        it('Test source_instance', function () {
             logObject = core.initLog();
             logObject.source_instance.should.equal("43");
         });
 
-        it('Test container_id: ', function () {
+        it('Test container_id', function () {
             logObject = core.initLog();
             logObject.container_id.should.equal("45");
         });
 
 
-        it('Test default values: ', function () {
+        it('Test default values', function () {
             delete process.env.VCAP_APPLICATION;
             delete process.env.CF_INSTANCE_IP;
             //resetting inherit memory for fast init
@@ -1928,7 +1928,7 @@ describe('Test log-core', function () {
             logObject.container_id.should.equal("-");
         });
 
-        it('Test static values: ', function () {
+        it('Test static values', function () {
             logObject = core.initLog();
             logObject.component_type.should.equal("application");
             logObject.layer.should.equal("[NODEJS]");

--- a/test/test-core.js
+++ b/test/test-core.js
@@ -318,7 +318,7 @@ describe('Test log-core', function () {
         });
     });
 
-    describe('Test setConfig environment var switches', function () {
+    describe('Test envVarRedact', function () {
         var core = rewire("../core/log-core.js");
         var coreConfig = null;
         var testConfig;
@@ -331,7 +331,7 @@ describe('Test log-core', function () {
             })
         });
 
-        it('Test unset switch: ', function () {
+        it('Test unset envVarRedact', function () {
             testConfig = [{
                 core: true
             }];
@@ -340,18 +340,106 @@ describe('Test log-core', function () {
             coreConfig[0].should.deep.equal({ core: true });
         });
 
-        it('Test set switch and unset env var: ', function () {
+        it('Test set envVarRedact and unset env var', function () {
             testConfig = [{
                 core: true,
-                envVarSwitch: "LOG_TEST_VAR"
+                envVarRedact: "LOG_TEST_VAR"
             }];
             process.env.LOG_TEST_VAR = undefined
             core.setConfig(testConfig);
             coreConfig.length.should.equal(1);
-            coreConfig[0].should.deep.equal({ core: true, envVarSwitch: "LOG_TEST_VAR", reduce: true });
+            coreConfig[0].should.deep.equal({ core: true, envVarRedact: "LOG_TEST_VAR", reduce: true });
         });
 
-        it('Test set switch and set env var ("true"): ', function () {
+        it('Test set envVarRedact and set env var ("true")', function () {
+            testConfig = [{
+                core: true,
+                envVarRedact: "LOG_TEST_VAR"
+            }];
+            process.env.LOG_TEST_VAR = 'true';
+            core.setConfig(testConfig);
+            coreConfig.length.should.equal(1);
+            coreConfig[0].should.deep.equal({ core: true, envVarRedact: "LOG_TEST_VAR" });
+        });
+
+        it('Test set envVarRedact and set env var ("True")', function () {
+            testConfig = [{
+                core: true,
+                envVarRedact: "LOG_TEST_VAR"
+            }];
+            process.env.LOG_TEST_VAR = 'True';
+            core.setConfig(testConfig);
+            coreConfig.length.should.equal(1);
+            coreConfig[0].should.deep.equal({ core: true, envVarRedact: "LOG_TEST_VAR" });
+        });
+
+        it('Test set envVarRedact and set env var ("true")', function () {
+            testConfig = [{
+                core: true,
+                envVarRedact: "LOG_TEST_VAR"
+            }];
+            process.env.LOG_TEST_VAR = 'TRUE';
+            core.setConfig(testConfig);
+            coreConfig.length.should.equal(1);
+            coreConfig[0].should.deep.equal({ core: true, envVarRedact: "LOG_TEST_VAR" });
+        });
+
+        it('Test set envVarRedact and set env var ("false")', function () {
+            testConfig = [{
+                core: true,
+                envVarRedact: "LOG_TEST_VAR"
+            }];
+            process.env.LOG_TEST_VAR = 'false';
+            core.setConfig(testConfig);
+            coreConfig.length.should.equal(1);
+            coreConfig[0].should.deep.equal({ core: true, envVarRedact: "LOG_TEST_VAR", reduce: true });
+        });
+
+        it('Test set envVarRedact and set env var ("0")', function () {
+            testConfig = [{
+                core: true,
+                envVarRedact: "LOG_TEST_VAR"
+            }];
+            process.env.LOG_TEST_VAR = '0';
+            core.setConfig(testConfig);
+            coreConfig.length.should.equal(1);
+            coreConfig[0].should.deep.equal({ core: true, envVarRedact: "LOG_TEST_VAR", reduce: true });
+        });
+    });
+
+    describe('Test envVarSwitch', function () {
+        var core = rewire("../core/log-core.js");
+        var coreConfig = null;
+        var testConfig;
+
+        before(function () {
+            core.__set__({
+                "prepareInitDummy": function (config) {
+                    coreConfig = config;
+                }
+            })
+        });
+
+        it('Test unset envVarSwitch', function () {
+            testConfig = [{
+                core: true
+            }];
+            core.setConfig(testConfig);
+            coreConfig.length.should.equal(1);
+            coreConfig[0].should.deep.equal({ core: true });
+        });
+
+        it('Test set envVarSwitch and unset env var', function () {
+            testConfig = [{
+                core: true,
+                envVarSwitch: "LOG_TEST_VAR"
+            }];
+            process.env.LOG_TEST_VAR = undefined;
+            core.setConfig(testConfig);
+            coreConfig.length.should.equal(0);
+        });
+
+        it('Test set envVarSwitch and set env var ("true")', function () {
             testConfig = [{
                 core: true,
                 envVarSwitch: "LOG_TEST_VAR"
@@ -362,7 +450,7 @@ describe('Test log-core', function () {
             coreConfig[0].should.deep.equal({ core: true, envVarSwitch: "LOG_TEST_VAR" });
         });
 
-        it('Test set switch and set env var ("True"): ', function () {
+        it('Test set envVarSwitch and set env var ("True")', function () {
             testConfig = [{
                 core: true,
                 envVarSwitch: "LOG_TEST_VAR"
@@ -373,7 +461,7 @@ describe('Test log-core', function () {
             coreConfig[0].should.deep.equal({ core: true, envVarSwitch: "LOG_TEST_VAR" });
         });
 
-        it('Test set switch and set env var ("true"): ', function () {
+        it('Test set envVarSwitch and set env var ("true")', function () {
             testConfig = [{
                 core: true,
                 envVarSwitch: "LOG_TEST_VAR"
@@ -384,26 +472,24 @@ describe('Test log-core', function () {
             coreConfig[0].should.deep.equal({ core: true, envVarSwitch: "LOG_TEST_VAR" });
         });
 
-        it('Test set switch and set env var ("false"): ', function () {
+        it('Test set envVarSwitch and set env var ("false")', function () {
             testConfig = [{
                 core: true,
                 envVarSwitch: "LOG_TEST_VAR"
             }];
             process.env.LOG_TEST_VAR = 'false';
             core.setConfig(testConfig);
-            coreConfig.length.should.equal(1);
-            coreConfig[0].should.deep.equal({ core: true, envVarSwitch: "LOG_TEST_VAR", reduce: true });
+            coreConfig.length.should.equal(0);
         });
 
-        it('Test set switch and set env var ("0"): ', function () {
+        it('Test set envVarSwitch and set env var ("0")', function () {
             testConfig = [{
                 core: true,
                 envVarSwitch: "LOG_TEST_VAR"
             }];
             process.env.LOG_TEST_VAR = '0';
             core.setConfig(testConfig);
-            coreConfig.length.should.equal(1);
-            coreConfig[0].should.deep.equal({ core: true, envVarSwitch: "LOG_TEST_VAR", reduce: true });
+            coreConfig.length.should.equal(0);
         });
     });
 

--- a/test/test-index.js
+++ b/test/test-index.js
@@ -121,7 +121,7 @@ describe('Test index.js', function () {
     });
     describe('Test parameter forwarding', function () {
 
-        it('Test forceLogger: ', function () {
+        it('Test forceLogger', function () {
             logger.forceLogger("express");
             linking.should.equal("express");
             logger.forceLogger("restify");
@@ -134,7 +134,7 @@ describe('Test index.js', function () {
             linking.should.equal("express");
         });
 
-        it('Test setLoggingLevel: ', function () {
+        it('Test setLoggingLevel', function () {
             var level = "testLevel";
             logger.setLoggingLevel(level);
             loggingLevel.should.equal(level);
@@ -149,7 +149,7 @@ describe('Test index.js', function () {
             loggingLevel.should.equal(level);
         });
 
-        it('Test getLoggingLevel: ', function () {
+        it('Test getLoggingLevel', function () {
             var loggingLevel = "testLevel";
             logger.getLoggingLevel().should.equal(loggingLevel);
             logger.forceLogger("restify");
@@ -160,12 +160,12 @@ describe('Test index.js', function () {
             logger.getLoggingLevel().should.equal(loggingLevel);
         });
 
-        it('Test isLoggingLevel: ', function () {
+        it('Test isLoggingLevel', function () {
             logger.isLoggingLevel("passLevel").should.equal(true);
             logger.isLoggingLevel("noPassLevel").should.equal(false);
         });
 
-        it('Test setSinkFunction: ', function () {
+        it('Test setSinkFunction', function () {
             var fct = (level, output) => {};
             logger.setSinkFunction(fct);
             sinkFunction.should.equal(fct);
@@ -180,13 +180,13 @@ describe('Test index.js', function () {
             sinkFunction.should.equal(fct);
         });
 
-        it('Test createLogger: ', function () {
+        it('Test createLogger', function () {
             var fields = {a: "1", b: "2"};
             logger.createLogger(fields);
             customFields.should.eql({a: "1", b: "2"});
         });
 
-        it('Test logMessage: ', function () {
+        it('Test logMessage', function () {
             var message = "testLevel";
             logger.logMessage(message);
             messageArgs.length.should.equal(1);
@@ -216,7 +216,7 @@ describe('Test index.js', function () {
             value.should.equal(value1);
         });
 
-        it('Test logNetwork: ', function () {
+        it('Test logNetwork', function () {
             var obj1 = {};
             var obj2 = {};
             var obj3 = {};
@@ -258,14 +258,14 @@ describe('Test index.js', function () {
             next.should.equal(obj3);
         });
 
-        it('Test winstonTransport: ', function () {
+        it('Test winstonTransport', function () {
             var obj = logger.createWinstonTransport({level: "debug"});
             assert.typeOf(obj, "object");
             obj.constructor.name.should.equal("CfNodejsLoggingSupportLogger");
             obj.level.should.equal("debug");
         });
 
-        it('Test setLogPattern: ' , function () {
+        it('Test setLogPattern' , function () {
             var pattern = "testing pattern {{msg}}";
             logger.setLogPattern(pattern);
             logPattern.should.equal(pattern);
@@ -285,7 +285,7 @@ describe('Test index.js', function () {
         });
 
 
-        it('Test setCustomFields: ' , function () {
+        it('Test setCustomFields' , function () {
            logger.setCustomFields({a: "3", b: "4"});
            customFields.should.eql({a: "3", b: "4"});
 
@@ -296,7 +296,7 @@ describe('Test index.js', function () {
            customFields.should.eql({});
         });
 
-        it('Test registerCustomFields: ' , function () {
+        it('Test registerCustomFields' , function () {
             logger.registerCustomFields({a: "3", b: "4"});
             registeredFields.should.eql({a: "3", b: "4"});
  

--- a/test/test-log-connect.js
+++ b/test/test-log-connect.js
@@ -1,6 +1,5 @@
 const importFresh = require('import-fresh');
 var chai = require("chai");
-var sinon = require("sinon");
 var assert = chai.assert;
 
 
@@ -14,6 +13,7 @@ describe('Test log-connect', function () {
         process.env.LOG_SENSITIVE_CONNECTION_DATA = true;
         process.env.LOG_REMOTE_USER = true;
         process.env.LOG_REFERER = true;
+        process.env.LOG_SSL_HEADERS = true;
 
         core = importFresh("../core/log-core.js");
         connectLogger = importFresh("../logger/log-connect.js");
@@ -21,21 +21,20 @@ describe('Test log-connect', function () {
         core.setConfig(importFresh("./allbranchconfig.js").config);
     });
 
-    describe('Test linkings', function () {
+    describe('Test binding', function () {
         var countSendLog;
-        var countInitLog;
+        var countInitRequestLog;
 
         beforeEach(function () {
             countSendLog = 0;
-            countInitLog = 0;
+            countInitRequestLog = 0;
 
             core.sendLog = function () {
                 countSendLog++;
             };
 
-            core.initBack = core.initRequestLog;
             core.initRequestLog = function () {
-                countInitLog++;
+                countInitRequestLog++;
                 var obj = {};
                 obj.level = "info";
                 return obj;
@@ -55,7 +54,7 @@ describe('Test log-connect', function () {
             };
             connectLogger.logNetwork(req, res, function () {});
             fireLog();
-            assert.equal(countInitLog, 1);
+            assert.equal(countInitRequestLog, 1);
             assert.equal(countSendLog, 1);
         });
     });
@@ -65,6 +64,8 @@ describe('Test log-connect', function () {
         var logObject = null;
         var req = {};
         var res = {};
+        var reqHeaders = [];
+        var resHeaders = [];
         var next;
 
         beforeEach(function () {
@@ -75,28 +76,32 @@ describe('Test log-connect', function () {
 
             next = function () {};
 
-            req = {};
-
-            req.connection = {};
-
-            req.headers = {};
-            req.getHeader = function (header) {
-                header = header.toLocaleLowerCase();
-                return this.headers[header];
-            }
-
-            res = {};
-            res.on = function (tag, func) {
-                if (tag == 'finish') {
-                    fireLog = func;
+            req = {
+                connection: {},
+                headers: {},
+                getHeader: function (header) {
+                    if (header == null) return;
+                    reqHeaders.push(header)
+                    return "test-header-req"
                 }
             };
 
-            res.get = function () {
-                return null;
+            res = {
+                headers: {},
+                on: function (tag, func) {
+                    if (tag == 'finish') {
+                        fireLog = func;
+                    }
+                },    
+                getHeader: function (header) {
+                    if (header == null) return;
+                    resHeaders.push(header)
+                    return "test-header-res"
+                }
             };
 
-            res._headers = {};
+            reqHeaders = [];
+            resHeaders = [];
         });
 
         it('Test request log level changing', function () {
@@ -121,221 +126,96 @@ describe('Test log-connect', function () {
             count.should.equal(1);
         });
 
-        describe('Test correlation_id', function () {
-            it('Test X-CorrelationID', function () {
-                req.headers["x-correlationid"] = "correctID";
+        describe('Test field handling', function () {
 
+            it('Test "static" field', function () {
                 connectLogger.logNetwork(req, res, next);
                 fireLog();
 
-                logObject.correlation_id.should.equal("correctID");
+                logObject.test_static.should.equal("test-value-static");
             });
 
-            it('Test generated uuid', function () {
+            it('Test "header" field (req)', function () {
+                reqHeaders = [];
                 connectLogger.logNetwork(req, res, next);
                 fireLog();
 
-                var uuid = logObject.correlation_id;
-                var pattern = new RegExp("[0-9a-fA-F]{8}-?[0-9a-fA-F]{4}-?4[0-9a-fA-F]{3}-?[89abAB][0-9a-fA-F]{3}-?[0-9a-fA-F]{12}");
-
-                pattern.test(uuid).should.equals(true);
+                logObject.test_header_req.should.equal("test-header-req");
+                reqHeaders.should.include("test-header-req");
             });
 
-            it('Test X-CorrelationID vs x-vcap-request-id', function () {
-                req.headers["x-correlationid"] = "correctID";
-                req.headers["x-vcap-request-id"] = "wrongID";
-
+            it('Test "header" field (res)', function () {
+                reqHeaders = [];
                 connectLogger.logNetwork(req, res, next);
                 fireLog();
 
-                logObject.correlation_id.should.equal("correctID");
+                logObject.test_header_res.should.equal("test-header-res");
+                resHeaders.should.include("test-header-res");
             });
-        });
 
-        it('Test request_id', function () {
-            req.headers["x-vcap-request-id"] = "correctID";
-
-            connectLogger.logNetwork(req, res, next);
-            fireLog();
-
-            logObject.request_id.should.equal("correctID");
-        });
-
-        it('Test tenant_id', function () {
-            req.headers["tenantid"] = "correctID";
-
-            connectLogger.logNetwork(req, res, next);
-            fireLog();
-
-            logObject.tenant_id.should.equal("correctID");
-        });
-
-        it('Test request', function () {
-            req.originalUrl = "correctUrl";
-
-            connectLogger.logNetwork(req, res, next);
-            fireLog();
-
-            logObject.request.should.equal("correctUrl");
-        });
-
-        it('Test response_status', function () {
-            res.statusCode = 418;
-
-            connectLogger.logNetwork(req, res, next);
-            fireLog();
-
-            logObject.response_status.should.equal(418);
-        });
-
-        it('Test method', function () {
-            req.method = "correctMethod";
-
-            connectLogger.logNetwork(req, res, next);
-            fireLog();
-
-            logObject.method.should.equal("correctMethod");
-        });
-
-        it('Test request_size_b', function () {
-            req.headers["content-length"] = 4711;
-            connectLogger.logNetwork(req, res, next);
-            fireLog();
-
-            logObject.request_size_b.should.equal(4711);
-        });
-
-        it('Test response_size_b', function () {
-            res.getHeader = function (field) {
-                if (field == "content-length") {
-                    return 4711;
-                }
-                return null;
-            };
-            connectLogger.logNetwork(req, res, next);
-            fireLog();
-
-            logObject.response_size_b.should.equal(4711);
-        });
-
-        it('Test remote_host', function () {
-            req.connection = {};
-            req.connection.remoteAddress = "correctAddress";
-            connectLogger.logNetwork(req, res, next);
-            fireLog();
-
-            logObject.remote_host.should.equal("correctAddress");
-        });
-
-        it('Test remote_port', function () {
-            req.connection = {};
-            req.connection.remotePort = "correctPort";
-            connectLogger.logNetwork(req, res, next);
-            fireLog();
-
-            logObject.remote_port.should.equal("correctPort");
-        });
-
-        it('Test x_forwarded_for', function () {
-            req.headers = {};
-            req.headers['x-forwarded-for'] = "testingHeader";
-            connectLogger.logNetwork(req, res, next);
-            fireLog();
-
-            logObject.x_forwarded_for.should.equal("testingHeader");
-        });
-
-        it('Test remote_ip', function () {
-            req.connection.remoteAddress = "correctAddress";
-            connectLogger.logNetwork(req, res, next);
-            fireLog();
-
-            logObject.remote_ip.should.equal("correctAddress");
-        });
-
-        it('Test response_content_type', function () {
-            res.getHeader = function (field) {
-                if (field == "content-type") {
-                    return "text/html;charset=UTF-8";
-                }
-            };
-            connectLogger.logNetwork(req, res, next);
-            fireLog();
-            logObject.response_content_type.should.equal("text/html;charset=UTF-8");
-        });
-
-        it('Test protocol', function () {
-            req.httpVersion = 1.1;
-            connectLogger.logNetwork(req, res, next);
-            fireLog();
-            logObject.protocol.should.equal("HTTP/1.1");
-        });
-
-        describe('Test timings', function () {
-            var clock;
-            before(function () {
-                clock = sinon.useFakeTimers();
-            });
-            after(function () {
-                clock.restore();
-            });
-            it('Test received_at', function () {
+            it('Test "self" field (req)', function () {
                 connectLogger.logNetwork(req, res, next);
                 fireLog();
-                logObject.request_received_at.should.equal((new Date()).toJSON());
+
+                logObject.test_self_req.should.equal("test-header-req");
             });
 
-            it('Test response_sent_at', function () {
+            it('Test "self" field (res)', function () {
                 connectLogger.logNetwork(req, res, next);
-                clock.tick(100);
                 fireLog();
-                logObject.response_sent_at.should.equal((new Date()).toJSON());
+
+                logObject.test_self_res.should.equal("test-header-res");
             });
 
-            it('Test response_time', function () {
+            it('Test "field" field (req)', function () {
+                req["test-field"] = "test-value-field-req";
                 connectLogger.logNetwork(req, res, next);
-                clock.tick(100);
                 fireLog();
 
-                logObject.response_time_ms.should.equal(100);
+                logObject.test_field_req.should.equal("test-value-field-req");
+            });
+
+            it('Test "field" field (res)', function () {
+                res["test-field"] = "test-value-field-res";
                 connectLogger.logNetwork(req, res, next);
-                clock.tick(50);
                 fireLog();
 
-                logObject.response_time_ms.should.equal(50);
+                logObject.test_field_res.should.equal("test-value-field-res");
+            });
+
+            it('Test "time" field (req+res)', function () {
+                connectLogger.logNetwork(req, res, next);
+                fireLog();
+                logObject.test_time.should.equal(3);
+            });
+
+            it('Test "special" field (req)', function () {
+                connectLogger.logNetwork(req, res, next);
+                fireLog();
+                logObject.test_special_req.should.equal("test-value-special-req");  
+            });
+
+            it('Test "special" field (res)', function () {
+                connectLogger.logNetwork(req, res, next);
+                fireLog();
+                logObject.test_special_res.should.equal("test-value-special-res");  
+            });
+
+
+            it('Test defaults (req)', function () {
+                connectLogger.logNetwork(req, res, next);
+                fireLog();
+                logObject.test_defaults_req.should.equal("test-default-req");  
+            });
+
+            it('Test defaults (res)', function () {
+                connectLogger.logNetwork(req, res, next);
+                fireLog();
+                logObject.test_defaults_res.should.equal("test-default-res");  
             });
         });
 
-
-        it('Test static fields', function () {
-            connectLogger.logNetwork(req, res, next);
-            fireLog();
-
-            logObject.type.should.equal("request");
-            logObject.referer.should.equal("-");
-            logObject.remote_user.should.equal("-");
-            logObject.direction.should.equal("IN");
-        });
-
-        it('Test default values', function () {
-            connectLogger.logNetwork(req, res, next);
-            fireLog();
-
-            logObject.request_id.should.equal("-");
-            logObject.tenant_id.should.equal("-");
-            logObject.request.should.equal("-");
-            logObject.method.should.equal("-");
-            logObject.request_size_b.should.equal(-1);
-            logObject.remote_host.should.equal("-");
-            logObject.response_size_b.should.equal(-1);
-            logObject.response_content_type.should.equal("-");
-            logObject.remote_port.should.equal("-");
-            logObject.x_forwarded_for.should.equal("");
-            logObject.protocol.should.equal("HTTP");
-            logObject.response_content_type.should.equal("-");
-        });
-
-        it("Test log ommitting per loging Level", function () {
+        it("Test log omitting per logging Level", function () {
             core.setLoggingLevel("error");
             connectLogger.logNetwork(req, res, next);
             fireLog();

--- a/test/test-log-plainhttp.js
+++ b/test/test-log-plainhttp.js
@@ -1,7 +1,7 @@
 const importFresh = require('import-fresh');
 var chai = require("chai");
-var sinon = require("sinon");
 var assert = chai.assert;
+
 
 chai.should();
 describe('Test log-plainhttp', function () {
@@ -9,33 +9,32 @@ describe('Test log-plainhttp', function () {
     var core = null;
     var httpLogger;
     beforeEach(function () {
-
         // Set env vars to enable logging of sensitive data
         process.env.LOG_SENSITIVE_CONNECTION_DATA = true;
         process.env.LOG_REMOTE_USER = true;
         process.env.LOG_REFERER = true;
+        process.env.LOG_SSL_HEADERS = true;
 
         core = importFresh("../core/log-core.js");
-        httpLogger = importFresh("../logger/log-plainhttp");
+        httpLogger = importFresh("../logger/log-plainhttp.js");
         httpLogger.setCoreLogger(core);
         core.setConfig(importFresh("./allbranchconfig.js").config);
     });
 
-    describe('Test linkings', function () {
+    describe('Test binding', function () {
         var countSendLog;
-        var countInitLog;
+        var countInitRequestLog;
 
         beforeEach(function () {
             countSendLog = 0;
-            countInitLog = 0;
+            countInitRequestLog = 0;
 
             core.sendLog = function () {
                 countSendLog++;
             };
 
-            core.initBack = core.initRequestLog;
             core.initRequestLog = function () {
-                countInitLog++;
+                countInitRequestLog++;
                 var obj = {};
                 obj.level = "info";
                 return obj;
@@ -43,7 +42,7 @@ describe('Test log-plainhttp', function () {
         });
 
         afterEach(function () {
-            core.initLog = core.initRequestLog;
+            core.initRequestLog = core.initRequestLog;
         })
 
         it("Test linking logNetwork", function () {
@@ -55,7 +54,7 @@ describe('Test log-plainhttp', function () {
             };
             httpLogger.logNetwork(req, res, function () {});
             fireLog();
-            assert.equal(countInitLog, 1);
+            assert.equal(countInitRequestLog, 1);
             assert.equal(countSendLog, 1);
         });
     });
@@ -65,6 +64,8 @@ describe('Test log-plainhttp', function () {
         var logObject = null;
         var req = {};
         var res = {};
+        var reqHeaders = [];
+        var resHeaders = [];
         var next;
 
         beforeEach(function () {
@@ -73,26 +74,34 @@ describe('Test log-plainhttp', function () {
                 logObject = logObj;
             };
 
-            next = function () { };
+            next = function () {};
 
-            req = {};
-
-            req.connection = {};
-            req.headers = {};
-            req.getHeader = function (header) {
-                header = header.toLocaleLowerCase();
-                return this.headers[header];
-            }
-
-
-            res = {};
-            res.on = function (tag, func) {
-                if (tag == 'finish') {
-                    fireLog = func;
+            req = {
+                connection: {},
+                headers: {},
+                getHeader: function (header) {
+                    if (header == null) return;
+                    reqHeaders.push(header)
+                    return "test-header-req"
                 }
             };
 
-            res._headers = {};
+            res = {
+                headers: {},
+                on: function (tag, func) {
+                    if (tag == 'finish') {
+                        fireLog = func;
+                    }
+                },    
+                getHeader: function (header) {
+                    if (header == null) return;
+                    resHeaders.push(header)
+                    return "test-header-res"
+                }
+            };
+
+            reqHeaders = [];
+            resHeaders = [];
         });
 
         it('Test request log level changing', function () {
@@ -117,225 +126,96 @@ describe('Test log-plainhttp', function () {
             count.should.equal(1);
         });
 
-        describe('Test correlation_id', function () {
-            it('Test X-CorrelationID', function () {
-                req.headers["x-correlationid"] = "correctID";
+        describe('Test field handling', function () {
 
+            it('Test "static" field', function () {
                 httpLogger.logNetwork(req, res, next);
                 fireLog();
 
-                logObject.correlation_id.should.equal("correctID");
+                logObject.test_static.should.equal("test-value-static");
             });
 
-            it('Test generated uuid', function () {
+            it('Test "header" field (req)', function () {
+                reqHeaders = [];
                 httpLogger.logNetwork(req, res, next);
                 fireLog();
 
-                var uuid = logObject.correlation_id;
-                var pattern = new RegExp("[0-9a-fA-F]{8}-?[0-9a-fA-F]{4}-?4[0-9a-fA-F]{3}-?[89abAB][0-9a-fA-F]{3}-?[0-9a-fA-F]{12}");
-
-                pattern.test(uuid).should.equals(true);
+                logObject.test_header_req.should.equal("test-header-req");
+                reqHeaders.should.include("test-header-req");
             });
 
-            it('Test X-CorrelationID vs x-vcap-request-id', function () {
-                req.headers["x-correlationid"] = "correctID";
-                req.headers["x-vcap-request-id"] = "wrongID";
-
+            it('Test "header" field (res)', function () {
+                reqHeaders = [];
                 httpLogger.logNetwork(req, res, next);
                 fireLog();
 
-                logObject.correlation_id.should.equal("correctID");
+                logObject.test_header_res.should.equal("test-header-res");
+                resHeaders.should.include("test-header-res");
             });
-        });
 
-        it('Test request_id', function () {
-            req.headers["x-vcap-request-id"] = "correctID";
-
-            httpLogger.logNetwork(req, res, next);
-            fireLog();
-
-            logObject.request_id.should.equal("correctID");
-        });
-
-        it('Test tenant_id', function () {
-            req.headers["tenantid"] = "correctID";
-
-            httpLogger.logNetwork(req, res, next);
-            fireLog();
-
-            logObject.tenant_id.should.equal("correctID");
-        });
-
-
-        it('Test request', function () {
-            req.url = "correctUrl";
-
-            httpLogger.logNetwork(req, res, next);
-            fireLog();
-
-            logObject.request.should.equal("correctUrl");
-        });
-
-        it('Test response_status', function () {
-            res.statusCode = 418;
-
-            httpLogger.logNetwork(req, res, next);
-            fireLog();
-
-            logObject.response_status.should.equal(418);
-        });
-
-        it('Test method', function () {
-            req.method = "correctMethod";
-
-            httpLogger.logNetwork(req, res, next);
-            fireLog();
-
-            logObject.method.should.equal("correctMethod");
-        });
-
-        it('Test request_size_b', function () {
-            req.headers["content-length"] = 4711;
-            httpLogger.logNetwork(req, res, next);
-            fireLog();
-
-            logObject.request_size_b.should.equal(4711);
-        });
-
-        it('Test response_size_b', function () {
-            res.getHeader = function (field) {
-                if (field == "content-length") {
-                    return 4711;
-                }
-                return null;
-            };
-            httpLogger.logNetwork(req, res, next);
-            fireLog();
-
-            logObject.response_size_b.should.equal(4711);
-        });
-
-        it('Test remote_host', function () {
-            req.connection = {};
-            req.connection.remoteAddress = "correctAddress";
-            httpLogger.logNetwork(req, res, next);
-            fireLog();
-
-            logObject.remote_host.should.equal("correctAddress");
-        });
-
-        it('Test remote_port', function () {
-            req.connection = {};
-            req.connection.remotePort = "correctPort";
-            httpLogger.logNetwork(req, res, next);
-            fireLog();
-
-            logObject.remote_port.should.equal("correctPort");
-        });
-
-        it('Test x_forwarded_for', function () {
-            req.headers['x-forwarded-for'] = "testingHeader";
-            httpLogger.logNetwork(req, res, next);
-            fireLog();
-
-            logObject.x_forwarded_for.should.equal("testingHeader");
-        });
-
-        it('Test referer', function () {
-            req.headers['referer'] = "testingReferer";
-            httpLogger.logNetwork(req, res, next);
-            fireLog();
-
-            logObject.referer.should.equal("testingReferer");
-        });
-
-
-        it('Test remote_ip', function () {
-            req.connection.remoteAddress = "correctAddress";
-            httpLogger.logNetwork(req, res, next);
-            fireLog();
-
-            logObject.remote_ip.should.equal("correctAddress");
-        });
-
-        it('Test response_content_type', function () {
-            res.getHeader = function (field) {
-                if (field == "content-type") {
-                    return "text/html;charset=UTF-8";
-                }
-            };
-            httpLogger.logNetwork(req, res, next);
-            fireLog();
-            logObject.response_content_type.should.equal("text/html;charset=UTF-8");
-        });
-
-        it('Test protocol', function () {
-            req.httpVersion = 1.1;
-            httpLogger.logNetwork(req, res, next);
-            fireLog();
-            logObject.protocol.should.equal("HTTP/1.1");
-        });
-
-        describe('Test timings', function () {
-            var clock;
-            before(function () {
-                clock = sinon.useFakeTimers();
-            });
-            after(function () {
-                clock.restore();
-            });
-            it('Test received_at', function () {
+            it('Test "self" field (req)', function () {
                 httpLogger.logNetwork(req, res, next);
                 fireLog();
-                logObject.request_received_at.should.equal((new Date()).toJSON());
+
+                logObject.test_self_req.should.equal("test-header-req");
             });
 
-            it('Test response_sent_at', function () {
+            it('Test "self" field (res)', function () {
                 httpLogger.logNetwork(req, res, next);
-                clock.tick(100);
-                fireLog();
-                logObject.response_sent_at.should.equal((new Date()).toJSON());
-            });
-
-            it('Test response_time', function () {
-                httpLogger.logNetwork(req, res, next);
-                clock.tick(100);
                 fireLog();
 
-                logObject.response_time_ms.should.equal(100);
+                logObject.test_self_res.should.equal("test-header-res");
+            });
+
+            it('Test "field" field (req)', function () {
+                req["test-field"] = "test-value-field-req";
+                httpLogger.logNetwork(req, res, next);
+                fireLog();
+
+                logObject.test_field_req.should.equal("test-value-field-req");
+            });
+
+            it('Test "field" field (res)', function () {
+                res["test-field"] = "test-value-field-res";
+                httpLogger.logNetwork(req, res, next);
+                fireLog();
+
+                logObject.test_field_res.should.equal("test-value-field-res");
+            });
+
+            it('Test "time" field (req+res)', function () {
+                httpLogger.logNetwork(req, res, next);
+                fireLog();
+                logObject.test_time.should.equal(3);
+            });
+
+            it('Test "special" field (req)', function () {
+                httpLogger.logNetwork(req, res, next);
+                fireLog();
+                logObject.test_special_req.should.equal("test-value-special-req");  
+            });
+
+            it('Test "special" field (res)', function () {
+                httpLogger.logNetwork(req, res, next);
+                fireLog();
+                logObject.test_special_res.should.equal("test-value-special-res");  
+            });
+
+
+            it('Test defaults (req)', function () {
+                httpLogger.logNetwork(req, res, next);
+                fireLog();
+                logObject.test_defaults_req.should.equal("test-default-req");  
+            });
+
+            it('Test defaults (res)', function () {
+                httpLogger.logNetwork(req, res, next);
+                fireLog();
+                logObject.test_defaults_res.should.equal("test-default-res");  
             });
         });
 
-
-        it('Test static fields', function () {
-            httpLogger.logNetwork(req, res, next);
-            fireLog();
-
-            logObject.type.should.equal("request");
-            logObject.referer.should.equal("-");
-            logObject.remote_user.should.equal("-");
-            logObject.direction.should.equal("IN");
-        });
-
-        it('Test default values', function () {
-            httpLogger.logNetwork(req, res, next);
-            fireLog();
-
-            logObject.request_id.should.equal("-");
-            logObject.tenant_id.should.equal("-");
-            logObject.request.should.equal("-");
-            logObject.method.should.equal("-");
-            logObject.request_size_b.should.equal(-1);
-            logObject.remote_host.should.equal("-");
-            logObject.response_size_b.should.equal(-1);
-            logObject.response_content_type.should.equal("-");
-            logObject.remote_port.should.equal("-");
-            logObject.x_forwarded_for.should.equal("");
-            logObject.protocol.should.equal("HTTP");
-            logObject.response_content_type.should.equal("-");
-        });
-
-        it("Test log ommitting per loging Level", function () {
+        it("Test log omitting per logging Level", function () {
             core.setLoggingLevel("error");
             httpLogger.logNetwork(req, res, next);
             fireLog();
@@ -345,7 +225,5 @@ describe('Test log-plainhttp', function () {
             fireLog();
             assert.isNotNull(logObject);
         });
-
-
     });
 });

--- a/test/test-log-restify.js
+++ b/test/test-log-restify.js
@@ -1,19 +1,19 @@
 const importFresh = require('import-fresh');
 var chai = require("chai");
-var sinon = require("sinon");
 var assert = chai.assert;
-chai.should();
 
+
+chai.should();
 describe('Test log-restify', function () {
 
     var core = null;
     var restifyLogger;
     beforeEach(function () {
-
         // Set env vars to enable logging of sensitive data
         process.env.LOG_SENSITIVE_CONNECTION_DATA = true;
         process.env.LOG_REMOTE_USER = true;
         process.env.LOG_REFERER = true;
+        process.env.LOG_SSL_HEADERS = true;
 
         core = importFresh("../core/log-core.js");
         restifyLogger = importFresh("../logger/log-restify.js");
@@ -21,23 +21,20 @@ describe('Test log-restify', function () {
         core.setConfig(importFresh("./allbranchconfig.js").config);
     });
 
-
-
-    describe('Test linkings', function () {
+    describe('Test binding', function () {
         var countSendLog;
-        var countInitLog;
+        var countInitRequestLog;
 
         beforeEach(function () {
             countSendLog = 0;
-            countInitLog = 0;
+            countInitRequestLog = 0;
 
             core.sendLog = function () {
                 countSendLog++;
             };
 
-            core.initBack = core.initRequestLog;
             core.initRequestLog = function () {
-                countInitLog++;
+                countInitRequestLog++;
                 var obj = {};
                 obj.level = "info";
                 return obj;
@@ -45,8 +42,8 @@ describe('Test log-restify', function () {
         });
 
         afterEach(function () {
-            core.initLog = core.initRequestLog;
-        });
+            core.initRequestLog = core.initRequestLog;
+        })
 
         it("Test linking logNetwork", function () {
             var req = {};
@@ -57,7 +54,7 @@ describe('Test log-restify', function () {
             };
             restifyLogger.logNetwork(req, res, function () {});
             fireLog();
-            assert.equal(countInitLog, 1);
+            assert.equal(countInitRequestLog, 1);
             assert.equal(countSendLog, 1);
         });
     });
@@ -67,6 +64,8 @@ describe('Test log-restify', function () {
         var logObject = null;
         var req = {};
         var res = {};
+        var reqHeaders = [];
+        var resHeaders = [];
         var next;
 
         beforeEach(function () {
@@ -75,275 +74,134 @@ describe('Test log-restify', function () {
                 logObject = logObj;
             };
 
-            next = function () { };
+            next = function () {};
 
-            req = {};
-            req.header = function () {
-                return null;
+            req = {
+                connection: {},
+                headers: {},
+                header: function (header) {
+                    if (header == null) return;
+                    reqHeaders.push(header)
+                    return "test-header-req"
+                }
             };
 
-            req.connection = {};
-            req.headers = {};
-
-
-            res = {};
-            res.on = function (tag, func) {
-                fireLog = func;
-            };
-
-            res.get = function () {
-                return null;
-            };
-        });
-
-        describe('Test correlation_id', function () {
-            it('Test X-CorrelationID', function () {
-                req.header = function (field) {
-                    if (field == "X-CorrelationID") {
-                        return "correctID";
+            res = {
+                headers: {},
+                on: function (tag, func) {
+                    if (tag == 'finish') {
+                        fireLog = func;
                     }
-                };
-
-                restifyLogger.logNetwork(req, res, next);
-                fireLog();
-
-                logObject.correlation_id.should.equal("correctID");
-            });
-
-            it('Test request log level changing', function () {
-                core.setRequestLogLevel("warn")    
-                restifyLogger.logNetwork(req, res, next);
-                fireLog();
-    
-                logObject.level.should.equal("warn");
-            });
-
-            it('Test generated uuid', function () {
-                restifyLogger.logNetwork(req, res, next);
-                fireLog();
-
-                var uuid = logObject.correlation_id;
-                var pattern = new RegExp("[0-9a-fA-F]{8}-?[0-9a-fA-F]{4}-?4[0-9a-fA-F]{3}-?[89abAB][0-9a-fA-F]{3}-?[0-9a-fA-F]{12}");
-
-                pattern.test(uuid).should.equals(true);
-            });
-
-            it('Test X-CorrelationID vs x-vcap-request-id', function () {
-                req.header = function (field) {
-                    if (field == "X-CorrelationID") {
-                        return "correctID";
-                    }
-                    if (field == "x-vcap-request-id") {
-                        return "wrongID";
-                    }
-                };
-
-                restifyLogger.logNetwork(req, res, next);
-                fireLog();
-
-                logObject.correlation_id.should.equal("correctID");
-            });
-        });
-
-        it('Test request_id', function () {
-            req.header = function (field) {
-                if (field == "x-vcap-request-id") {
-                    return "correctID";
+                },    
+                get: function (header) {
+                    if (header == null) return;
+                    resHeaders.push(header)
+                    return "test-header-res"
                 }
             };
 
+            reqHeaders = [];
+            resHeaders = [];
+        });
+
+        it('Test request log level changing', function () {
+            core.setRequestLogLevel("warn")    
             restifyLogger.logNetwork(req, res, next);
             fireLog();
 
-            logObject.request_id.should.equal("correctID");
+            logObject.level.should.equal("warn");
         });
 
-        it('Test tenant_id', function () {
-            req.header = function (field) {
-                if (field == "tenantid") {
-                    return "correctID";
-                }
-            };
+        describe('Test field handling', function () {
 
-            restifyLogger.logNetwork(req, res, next);
-            fireLog();
-
-            logObject.tenant_id.should.equal("correctID");
-        });
-
-
-        it('Test request', function () {
-            req.url = "correctUrl";
-
-            restifyLogger.logNetwork(req, res, next);
-            fireLog();
-
-            logObject.request.should.equal("correctUrl");
-        });
-
-        it('Test response_status', function () {
-            res.statusCode = 418;
-
-            restifyLogger.logNetwork(req, res, next);
-            fireLog();
-
-            logObject.response_status.should.equal(418);
-        });
-
-        it('Test method', function () {
-            req.method = "correctMethod";
-
-            restifyLogger.logNetwork(req, res, next);
-            fireLog();
-
-            logObject.method.should.equal("correctMethod");
-        });
-
-        it('Test request_size_b', function () {
-            req.header = function (field) {
-                if (field == "content-length") {
-                    return 4711;
-                }
-                return null;
-            };
-            restifyLogger.logNetwork(req, res, next);
-            fireLog();
-
-            logObject.request_size_b.should.equal(4711);
-        });
-
-        it('Test response_size_b', function () {
-            res.get = function (field) {
-                if (field == "content-length") {
-                    return 4711;
-                }
-                return null;
-            };
-            restifyLogger.logNetwork(req, res, next);
-            fireLog();
-
-            logObject.response_size_b.should.equal(4711);
-        });
-
-        it('Test remote_host', function () {
-            req.connection = {};
-            req.connection.remoteAddress = "correctAddress";
-            restifyLogger.logNetwork(req, res, next);
-            fireLog();
-
-            logObject.remote_host.should.equal("correctAddress");
-        });
-
-        it('Test remote_port', function () {
-            req.connection = {};
-            req.connection.remotePort = "correctPort";
-            restifyLogger.logNetwork(req, res, next);
-            fireLog();
-
-            logObject.remote_port.should.equal("correctPort");
-        });
-
-        it('Test x_forwarded_for', function () {
-            req.headers = {};
-            req.headers['x-forwarded-for'] = "testingHeader";
-            restifyLogger.logNetwork(req, res, next);
-            fireLog();
-
-            logObject.x_forwarded_for.should.equal("testingHeader");
-        });
-
-        it('Test remote_ip', function () {
-            req.connection.remoteAddress = "correctAddress";
-            restifyLogger.logNetwork(req, res, next);
-            fireLog();
-
-            logObject.remote_ip.should.equal("correctAddress");
-        });
-
-        it('Test response_content_type', function () {
-            res.get = function (field) {
-                if (field == "content-type") {
-                    return "text/html;charset=UTF-8";
-                }
-            };
-            restifyLogger.logNetwork(req, res, next);
-            fireLog();
-            logObject.response_content_type.should.equal("text/html;charset=UTF-8");
-        });
-
-        it('Test protocol', function () {
-            req.httpVersion = 1.1;
-            restifyLogger.logNetwork(req, res, next);
-            fireLog();
-            logObject.protocol.should.equal("HTTP/1.1");
-        });
-
-        describe('Test timings', function () {
-            var clock;
-            before(function () {
-                clock = sinon.useFakeTimers();
-            });
-            after(function () {
-                clock.restore();
-            });
-            it('Test received_at', function () {
+            it('Test "static" field', function () {
                 restifyLogger.logNetwork(req, res, next);
                 fireLog();
-                logObject.request_received_at.should.equal((new Date()).toJSON());
+
+                logObject.test_static.should.equal("test-value-static");
+            });
+
+            it('Test "header" field (req)', function () {
+                reqHeaders = [];
+                restifyLogger.logNetwork(req, res, next);
+                fireLog();
+
+                logObject.test_header_req.should.equal("test-header-req");
+                reqHeaders.should.include("test-header-req");
+            });
+
+            it('Test "header" field (res)', function () {
+                reqHeaders = [];
+                restifyLogger.logNetwork(req, res, next);
+                fireLog();
+
+                logObject.test_header_res.should.equal("test-header-res");
+                resHeaders.should.include("test-header-res");
+            });
+
+            it('Test "self" field (req)', function () {
+                restifyLogger.logNetwork(req, res, next);
+                fireLog();
+
+                logObject.test_self_req.should.equal("test-header-req");
+            });
+
+            it('Test "self" field (res)', function () {
+                restifyLogger.logNetwork(req, res, next);
+                fireLog();
+
+                logObject.test_self_res.should.equal("test-header-res");
+            });
+
+            it('Test "field" field (req)', function () {
+                req["test-field"] = "test-value-field-req";
+                restifyLogger.logNetwork(req, res, next);
+                fireLog();
+
+                logObject.test_field_req.should.equal("test-value-field-req");
+            });
+
+            it('Test "field" field (res)', function () {
+                res["test-field"] = "test-value-field-res";
+                restifyLogger.logNetwork(req, res, next);
+                fireLog();
+
+                logObject.test_field_res.should.equal("test-value-field-res");
+            });
+
+            it('Test "time" field (req+res)', function () {
+                restifyLogger.logNetwork(req, res, next);
+                fireLog();
+                logObject.test_time.should.equal(3);
+            });
+
+            it('Test "special" field (req)', function () {
+                restifyLogger.logNetwork(req, res, next);
+                fireLog();
+                logObject.test_special_req.should.equal("test-value-special-req");  
+            });
+
+            it('Test "special" field (res)', function () {
+                restifyLogger.logNetwork(req, res, next);
+                fireLog();
+                logObject.test_special_res.should.equal("test-value-special-res");  
             });
 
 
-            it('Test response_sent_at', function () {
+            it('Test defaults (req)', function () {
                 restifyLogger.logNetwork(req, res, next);
-                clock.tick(100);
                 fireLog();
-                logObject.response_sent_at.should.equal((new Date()).toJSON());
+                logObject.test_defaults_req.should.equal("test-default-req");  
             });
 
-            it('Test response_time', function () {
+            it('Test defaults (res)', function () {
                 restifyLogger.logNetwork(req, res, next);
-                clock.tick(100);
                 fireLog();
-
-                logObject.response_time_ms.should.equal(100);
-                restifyLogger.logNetwork(req, res, next);
-                clock.tick(50);
-                fireLog();
-
-                logObject.response_time_ms.should.equal(50);
+                logObject.test_defaults_res.should.equal("test-default-res");  
             });
         });
 
-
-        it('Test static fields', function () {
-            restifyLogger.logNetwork(req, res, next);
-            fireLog();
-
-            logObject.type.should.equal("request");
-            logObject.referer.should.equal("-");
-            logObject.remote_user.should.equal("-");
-            logObject.direction.should.equal("IN");
-        });
-
-        it('Test default values', function () {
-            restifyLogger.logNetwork(req, res, next);
-            fireLog();
-
-            logObject.request_id.should.equal("-");
-            logObject.tenant_id.should.equal("-");
-            logObject.request.should.equal("-");
-            logObject.method.should.equal("-");
-            logObject.request_size_b.should.equal(-1);
-            logObject.remote_host.should.equal("-");
-            logObject.response_size_b.should.equal(-1);
-            logObject.response_content_type.should.equal("-");
-            logObject.remote_port.should.equal("-");
-            logObject.x_forwarded_for.should.equal("");
-            logObject.protocol.should.equal("HTTP");
-            logObject.response_content_type.should.equal("-");
-        });
-
-        it("Test log ommitting per loging Level", function () {
+        it("Test log omitting per logging Level", function () {
             core.setLoggingLevel("error");
             restifyLogger.logNetwork(req, res, next);
             fireLog();


### PR DESCRIPTION
- Log HTTP proxy headers that may be generated by reverse proxies for incoming requests. (redacted by default, revealed when `LOG_SENSITIVE_CONNECTION_DATA` is set to `true`)
- Log SSL headers (optionally, if `LOG_SSL_HEADERS` env var is set to `true`)
- Adapt/add test cases for above fields.
- Replace logger tests with more generic test cases to avoid duplication of config specific tests.
- Fix multiple typos.
- Add homepage to package.json.