### PR TITLE
Read remote_user from req.user.id field

### DIFF
--- a/config.js
+++ b/config.js
@@ -232,10 +232,15 @@ var config = [
         mandatory: true,
         envVarRedact: "LOG_REMOTE_USER",
         source: {
-            type: "header",
-            name: "remote-user"
+            type: "special",
+            parent: "res", // use "res" to force late evaluation
         },
-        default: "-"
+        fallback: (req, res, logObj) => {
+            if (req.user && req.user.id) {
+                return req.user.id;
+            }
+            return "-"
+        }
     }, {
         name: "direction",
         mandatory: true,

--- a/test/test-complete.js
+++ b/test/test-complete.js
@@ -70,13 +70,15 @@ describe('Test Complete', function () {
         req = httpMock.createRequest({
             headers: {
                 "x-correlationid": "test-correlation-id",
-                "remote-user": "test-user",
                 "x-forwarded-for": "host-1",
                 "x-forwarded-host": "host-2",
                 "x-forwarded-proto": "https",
                 "x-custom-host": "host-3"
             }
         });
+        req.user = {
+            id: "test-user"
+        };
         res = httpMock.createResponse();
         prepare(res);
         log.overrideNetworkField("msg","testmessage");

--- a/test/test-config.js
+++ b/test/test-config.js
@@ -203,11 +203,13 @@ describe('Test config', function () {
 
         it('Test remote_user', function () {
             req.headers = {};
-            req.headers['remote-user'] = "testingName";
+            req.user = {
+                id: "test-user"
+            };
             httpLogger.logNetwork(req, res, next);
             fireLog();
 
-            logObject.remote_user.should.equal("testingName");
+            logObject.remote_user.should.equal("test-user");
         });
 
         it('Test connection data propagation', function() {


### PR DESCRIPTION
- Change source of `remote_user` field to `req.user.id`.
- This allows logging user id in combination with authentication middleware.
  - Passport: https://www.npmjs.com/package/passport  
  - Environment variable LOG_REMOTE_USER has to be set to "true" to enable writing the `remote_user` field.
- Update tests.