### PR TITLE
Add support for logging stack traces

### DIFF
--- a/core/log-core.js
+++ b/core/log-core.js
@@ -92,18 +92,18 @@ var init = function () {
 
     //Reading bindings from context
     var boundServices = parseJSONSafe(process.env.VCAP_SERVICES);
-    if(boundServices["application-logs"]) {
+    if (boundServices["application-logs"]) {
         cfCustomEnabled = true;
         defaultCustomEnabled = false;
     }
-    if(boundServices["cloud-logs"]) {
+    if (boundServices["cloud-logs"]) {
         defaultCustomEnabled = true;
     }
 };
 
 var parseJSONSafe = function (value) {
     var tmp = {};
-    if(value)
+    if (value)
         try {
             tmp = JSON.parse(value);
         } catch (e) {
@@ -134,7 +134,7 @@ var precompileConfig = function (config) {
             var val = process.env[obj.envVarSwitch];
             var pass = (val == "true" || val == "True" || val == "TRUE");
             if (!pass) {
-                continue; 
+                continue;
             }
         }
 
@@ -283,9 +283,9 @@ var setLoggingLevel = function (level) {
     }
 };
 
-var setRequestLogLevel = function(level) {
+var setRequestLogLevel = function (level) {
     levelInt = getLogLevelFromName(level);
-    if(levelInt != null) {
+    if (levelInt != null) {
         requestLogLevel = level;
         return true;
     }
@@ -327,7 +327,7 @@ var initLog = function () {
     logObject.written_ts = higher + lower;
     //This reorders written_ts, if the new timestamp seems to be smaller
     // due to different rollover times for process.hrtime and now.getTime
-    if(logObject.written_ts < lastTimestamp)
+    if (logObject.written_ts < lastTimestamp)
         logObject.written_ts += NS_PER_MS;
     lastTimestamp = logObject.written_ts;
     return logObject;
@@ -463,7 +463,7 @@ var logMessage = function () {
         if (isErrorWithStacktrace(lastArg)) {
             logObject.stacktrace = prepareStacktrace(lastArg.stack);
         } else if (isValidObject(lastArg)) {
-            customFieldsFromArgs = lastArg;   
+            customFieldsFromArgs = lastArg;
         }
         args.pop();
     }
@@ -564,7 +564,7 @@ var getTenantSubdomain = function () {
 
 // Registers a (white)list of allowed custom field names
 var registerCustomFields = function (fieldNames) {
-    
+
     registeredCustomFields = [];
 
     if (!Array.isArray(fieldNames)) return false;
@@ -647,7 +647,7 @@ var writeCustomFields = function (logObject, logger, additionalFields) {
             value = stringifySafe(value);
         }
 
-        if(defaultCustomEnabled || logObject[key] != null || isSettable(key))
+        if (defaultCustomEnabled || logObject[key] != null || isSettable(key))
             logObject[key] = value;
 
         if (cfCustomEnabled)
@@ -661,24 +661,24 @@ var writeCustomFields = function (logObject, logger, additionalFields) {
         res.string = [];
         counter = 0;
         var key;
-        for(var i = 0; i < registeredCustomFields.length; i++) {
+        for (var i = 0; i < registeredCustomFields.length; i++) {
             key = registeredCustomFields[i]
-            if(customFields[key])
+            if (customFields[key])
                 res.string.push({
                     "k": key,
                     "v": customFields[key],
                     "i": i
                 })
         }
-        if(res.string.length > 0)
+        if (res.string.length > 0)
             logObject["#cf"] = res;
     }
 }
 
-var isSettable = function(key) {
+var isSettable = function (key) {
     if (settableConfig.length == 0) return false;
-    for(var i = 0; i < settableConfig.length; i++) {
-        if(settableConfig[i] == key) return true;
+    for (var i = 0; i < settableConfig.length; i++) {
+        if (settableConfig[i] == key) return true;
     }
     return false;
 }
@@ -782,7 +782,7 @@ var isValidObject = function (obj, canBeEmpty) {
 };
 
 // check if the given object is an Error with stacktrace using duck typing
-var isErrorWithStacktrace = function(obj) {
+var isErrorWithStacktrace = function (obj) {
     if (obj && obj.stack && obj.message && typeof obj.stack === "string" && typeof obj.message === "string") {
         return true;
     }
@@ -791,9 +791,9 @@ var isErrorWithStacktrace = function(obj) {
 
 // Split stacktrace into string array and truncate lines if required by size limitation
 // Truncation strategy: Take one line from the top and two lines from the bottom of the stacktrace until limit is reached.
-var prepareStacktrace = function(stacktraceStr) {
+var prepareStacktrace = function (stacktraceStr) {
     var fullStacktrace = stacktraceStr.split('\n');
-    var totalLineLength = fullStacktrace.reduce((p, c) => p + c.length, 0)
+    var totalLineLength = fullStacktrace.reduce((acc, line) => acc + line.length, 0);
 
     if (totalLineLength > MAX_STACKTRACE_SIZE) {
         var truncatedStacktrace = [];
@@ -809,7 +809,7 @@ var prepareStacktrace = function(stacktraceStr) {
                 if (currentLength + line.length > MAX_STACKTRACE_SIZE) {
                     break;
                 }
-                currentLength += line.length
+                currentLength += line.length;
                 stackA.push(line);
                 indexA++;
             } else {
@@ -817,16 +817,16 @@ var prepareStacktrace = function(stacktraceStr) {
                 if (currentLength + line.length > MAX_STACKTRACE_SIZE) {
                     break;
                 }
-                currentLength += line.length
+                currentLength += line.length;
                 stackB.push(line);
                 indexB--;
             }
         }
-        
-        truncatedStacktrace.push("-------- STACK TRACE TRUNCATED --------")
-        truncatedStacktrace = [...truncatedStacktrace, ...stackA]
-        truncatedStacktrace.push(`-------- OMITTED ${fullStacktrace.length - (stackA.length + stackB.length)} LINES --------`)
-        truncatedStacktrace = [...truncatedStacktrace, ...stackB.reverse()]
+
+        truncatedStacktrace.push("-------- STACK TRACE TRUNCATED --------");
+        truncatedStacktrace = [...truncatedStacktrace, ...stackA];
+        truncatedStacktrace.push(`-------- OMITTED ${fullStacktrace.length - (stackA.length + stackB.length)} LINES --------`);
+        truncatedStacktrace = [...truncatedStacktrace, ...stackB.reverse()];
         return truncatedStacktrace;
     }
     return fullStacktrace;
@@ -854,8 +854,8 @@ var overrideField = function (field, value) {
 };
 
 //Sets the custom field format by hand. Returns true on correct strings.
-var overrideCustomFieldFormat = function(value) {
-    if(typeof value == "string") {
+var overrideCustomFieldFormat = function (value) {
+    if (typeof value == "string") {
         switch (value) {
             case "application-logging":
                 defaultCustomEnabled = false;

--- a/core/log-core.js
+++ b/core/log-core.js
@@ -804,23 +804,21 @@ var prepareStacktrace = function (stacktraceStr) {
         var indexB = fullStacktrace.length - 1;
         var currentLength = 73; // set to approx. character count for "truncated" and "omitted" labels
 
-        for (var i = 0; i < fullStacktrace.length; i++) {
+        for (let i = 0; i < fullStacktrace.length; i++) {
             if (i % 3 == 0) {
-                var line = fullStacktrace[indexA];
+                let line = fullStacktrace[indexA++];
                 if (currentLength + line.length > MAX_STACKTRACE_SIZE) {
                     break;
                 }
                 currentLength += line.length;
                 stackA.push(line);
-                indexA++;
             } else {
-                var line = fullStacktrace[indexB];
+                let line = fullStacktrace[indexB--];
                 if (currentLength + line.length > MAX_STACKTRACE_SIZE) {
                     break;
                 }
                 currentLength += line.length;
                 stackB.push(line);
-                indexB--;
             }
         }
 

--- a/core/log-core.js
+++ b/core/log-core.js
@@ -454,15 +454,16 @@ var logMessage = function () {
 
     args.shift();
 
-
     var customFieldsFromArgs = {};
-    var stacktrace = null;
-
     var lastArg = args[args.length - 1];
     if (typeof lastArg === "object") {
         if (isErrorWithStacktrace(lastArg)) {
             logObject.stacktrace = prepareStacktrace(lastArg.stack);
         } else if (isValidObject(lastArg)) {
+            if (isErrorWithStacktrace(lastArg._error)) {
+                logObject.stacktrace = prepareStacktrace(lastArg._error.stack);
+                delete lastArg._error;
+            }
             customFieldsFromArgs = lastArg;
         }
         args.pop();

--- a/docs/general-usage/02-message-logs.md
+++ b/docs/general-usage/02-message-logs.md
@@ -101,8 +101,9 @@ try {
 ```
 
 Stack traces get written to the `stacktrace` field of the log and are represented as an array of strings.
-If a stack trace exceeds a total size of 55kB, it will therefore not be logged entirely.
-Since the interesting lines of a stack trace are usually situated in its first and in its last part, we will remove as few lines as necessary from its middle part.
+If a stack trace exceeds a total size of 55kB, it will not be logged entirely.
+The library removes as few lines as necessary from the middle of the stack trace since the relevant parts are usually at the start and the end.
+We use following strategy to do so: Take one line from the top and two lines from the bottom of the stacktrace until the limit is reached.
 
 ## Checking log severity levels
 

--- a/docs/general-usage/02-message-logs.md
+++ b/docs/general-usage/02-message-logs.md
@@ -87,24 +87,6 @@ In the simplest case, `logger` is an instance of imported `log` module.
   // ... "msg":"Hello World" ...
   ```
 
-## Logging stack traces
-
-For logging stack traces as part of an error message you can append the `Error` object as follows:
-
-```js
-try {
-  // Code throwing an Error
-} catch (e) {
-  logger.error("Error occurred", e)
-}
-// ... "msg":"Error occurred", "stacktrace": [...] ...
-```
-
-Stack traces get written to the `stacktrace` field of the log and are represented as an array of strings.
-If a stack trace exceeds a total size of 55kB, it will not be logged entirely.
-The library removes as few lines as necessary from the middle of the stack trace since the relevant parts are usually at the start and the end.
-We use following strategy to do so: Take one line from the top and two lines from the bottom of the stacktrace until the limit is reached.
-
 ## Checking log severity levels
 
 It can be useful to check if messages with a specific severity level would be logged.

--- a/docs/general-usage/02-message-logs.md
+++ b/docs/general-usage/02-message-logs.md
@@ -80,6 +80,23 @@ logger.logMessage(level, "Hello World");
 // ... "msg":"Hello World" ...
 ```
 
+## Logging errors with stack traces
+
+You can append an `Error` object to a message to log its stack trace:
+
+```js
+try {
+  // Code throwing an Error
+} catch (e) {
+  logger.error("Error occurred", e)
+}
+// ... "msg":"Error occurred", "stacktrace": [...] ...
+```
+
+Stack traces get written to the `stacktrace` field of the log and are represented as array of strings.
+If a stack trace exceeds a total size of 55kB, it will therefore not be logged entirely.
+Since the interesting lines of a stack trace are usually situated in its first and in its last part, we will remove as few lines as necessary from its middle part.
+
 ## Checking log severity levels
 It can be useful to check if messages with a specific severity level would be logged. 
 You can check if a logging level is active as follows:

--- a/docs/general-usage/02-message-logs.md
+++ b/docs/general-usage/02-message-logs.md
@@ -9,8 +9,8 @@ permalink: /general-usage/message-logs
 # Message Logs
 {: .no_toc }
 
-In addition to request logging this library also supports logging of application messages. 
-Message logs contain at least some message and also CF metadata. 
+In addition to request logging this library also supports logging of application messages.
+Message logs contain at least some message and also CF metadata.
 
 <details open markdown="block">
   <summary>
@@ -22,6 +22,7 @@ Message logs contain at least some message and also CF metadata.
 </details>
 
 ## Logging levels
+
 Following common logging levels are supported:
 
 - `error`
@@ -32,6 +33,7 @@ Following common logging levels are supported:
 - `silly`
 
 Set the minimum logging level for logs as follows:
+
 ```js
 log.setLoggingLevel("info");
 ```
@@ -39,50 +41,55 @@ log.setLoggingLevel("info");
 In addition there is an off logging level available to disable log output completely.
 
 ## Writing message logs
+
 There are so called *convenience methods* available for all supported logging levels.
 These can be called to log a message using the corresponding level. 
 It is also possible to use standard format placeholders equivalent to the [util.format](https://nodejs.org/api/util.html#util_util_format_format_args) method.
 
-You can find several usage examples below demonstrating options to be specified when calling a log method. 
-All methods get called on a `logger` object, which provides a so called *logging context*. 
+You can find several usage examples below demonstrating options to be specified when calling a log method.
+All methods get called on a `logger` object, which provides a so called *logging context*.
 You can find more information about logging contexts in the [Logging Contexts](/cf-nodejs-logging-support/general-usage/logging-contexts) chapter.
-In the simplest case, `logger` is an instance of imported `log` module. 
+In the simplest case, `logger` is an instance of imported `log` module.
 
-- Simple message
-```js
-logger.info("Hello World"); 
-// ... "msg":"Hello World" ...
-```
+- Simple message:
 
-- Message with additional numeric value
-```js
-logger.info("Listening on port %d", 5000); 
-// ... "msg":"Listening on port 5000" ...
-```
+  ```js
+  logger.info("Hello World"); 
+  // ... "msg":"Hello World" ...
+  ```
 
-- Message with additional string values
-```js
-logger.info("This %s a %s", "is", "test"); 
-// ... "msg":"This is a test" ...
-```
+- Message with additional numeric value:
 
-- Message with additional json object to be embedded in to the message
-```js
-logger.info("Test data %j", {"field" :"value"}, {}); 
-// ... "msg":"Test data {\"field\": \"value\"}" ...
-```
+  ```js
+  logger.info("Listening on port %d", 5000); 
+  // ... "msg":"Listening on port 5000" ...
+  ```
 
-In some cases you might want to set the actual logging level from a variable. 
-Instead of using conditional expressions you can simply use following method, which also supports format features described above.
-```js
-var level = "debug";
-logger.logMessage(level, "Hello World"); 
-// ... "msg":"Hello World" ...
-```
+- Message with additional string values:
 
-## Logging errors with stack traces
+  ```js
+  logger.info("This %s a %s", "is", "test"); 
+  // ... "msg":"This is a test" ...
+  ```
 
-You can append an `Error` object to a message to log its stack trace:
+- Message with additional json object to be embedded in to the message:
+
+  ```js
+  logger.info("Test data %j", {"field" :"value"}, {}); 
+  // ... "msg":"Test data {\"field\": \"value\"}" ...
+  ```
+
+- In case you want to set the actual logging level from a variable, you can use following method, which also supports format features described above:
+
+  ```js
+  var level = "debug";
+  logger.logMessage(level, "Hello World"); 
+  // ... "msg":"Hello World" ...
+  ```
+
+## Logging stack traces
+
+For logging stack traces as part of an error message you can append the `Error` object as follows:
 
 ```js
 try {
@@ -93,12 +100,13 @@ try {
 // ... "msg":"Error occurred", "stacktrace": [...] ...
 ```
 
-Stack traces get written to the `stacktrace` field of the log and are represented as array of strings.
+Stack traces get written to the `stacktrace` field of the log and are represented as an array of strings.
 If a stack trace exceeds a total size of 55kB, it will therefore not be logged entirely.
 Since the interesting lines of a stack trace are usually situated in its first and in its last part, we will remove as few lines as necessary from its middle part.
 
 ## Checking log severity levels
-It can be useful to check if messages with a specific severity level would be logged. 
+
+It can be useful to check if messages with a specific severity level would be logged.
 You can check if a logging level is active as follows:
 
 ```js
@@ -109,6 +117,7 @@ if (isInfoActive) {
 ```
 
 There are convenience methods available for this feature:
+
 ```js
 var isDebugActive = log.isDebug();
 ```

--- a/docs/general-usage/05-stacktraces.md
+++ b/docs/general-usage/05-stacktraces.md
@@ -1,0 +1,42 @@
+---
+layout: default
+title: Logging Stack Traces
+parent: General Usage
+nav_order: 5
+permalink: /general-usage/stacktraces
+---
+
+# Stack Traces
+
+Stack traces can be written to the `stacktrace` field of the log and are represented as an array of strings.
+
+If a stack trace exceeds a total size of 55kB, it will not be logged entirely.
+The library removes as few lines as necessary from the middle of the stack trace since the relevant parts are usually at the start and the end.
+We use following strategy to do so:
+
+- Take one line from the top and two lines from the bottom of the stacktrace until the limit is reached.
+
+For writing stack traces as part of a message log you can append the `Error` object as follows:
+
+```js
+try {
+  // Code throwing an Error
+} catch (e) {
+  logger.error("Error occurred", e)
+}
+// ... "msg":"Error occurred", "stacktrace": [...] ...
+```
+
+In case you want to a log stack traces along with custom fields you can attach it as follows:
+
+```js
+try {
+  // Code throwing an Error
+} catch (e) {
+  logger.error("Error occurred", {"custom-field" :"value", "_error": e})
+}
+// ... "msg":"Error occurred", "stacktrace": [...] ...
+```
+
+The `_error` field gets handled separately and its stack trace gets written to the `stacktrace` field.
+The given custom fields get handled as described in [Custom Fields](/cf-nodejs-logging-support/general-usage/custom-fields).

--- a/test/test-core.js
+++ b/test/test-core.js
@@ -1535,6 +1535,28 @@ describe('Test log-core', function () {
             assert.equal(logObject["#cf"], null);
         });
 
+        it("Test logging custom fields along with error", function () {
+            overrideCustomFieldFormat("default");
+
+            var e = new Error("test-message");
+            log("info", "Test", {
+                "a": "string",
+                "b": 1337,
+                "_error": e
+            });
+
+            logObject.msg.should.equal('Test');
+            logObject.a.should.equal("string");
+            logObject.b.should.equal("1337");
+
+            assert.isArray(logObject.stacktrace);
+            assert.equal(logObject["_error"], null);
+
+            logObject.stacktrace.length.should.greaterThan(5);
+            logObject.stacktrace[0].should.equal("Error: test-message");
+            assert.equal(logObject["#cf"], null);
+        });
+
         it("Test disabled custom fields", function () {
             registerCustomFields(["a", "b", "c"]);
             overrideCustomFieldFormat("disabled");

--- a/test/test-core.js
+++ b/test/test-core.js
@@ -172,7 +172,7 @@ describe('Test log-core', function () {
                     type: "static",
                     value: "42"
                 }
-            },{
+            }, {
                 name: "settable_field",
                 type: "settable"
             }
@@ -190,11 +190,11 @@ describe('Test log-core', function () {
         });
 
         it('Test config assignment (settable)', function () {
-            log("info","test", {"settable_field":"settable","non_settable":"test"})
-            
+            log("info", "test", { "settable_field": "settable", "non_settable": "test" })
+
             logObject.settable_field.should.equal("settable");
             assert.equal(logObject.non_settable, null);
-            
+
         });
 
         it('Test settable propagation', function () {
@@ -207,7 +207,7 @@ describe('Test log-core', function () {
             })
 
             core.__get__("settableConfig").should.deep.equal(["settable_field"]);
-            
+
         });
     });
 
@@ -563,7 +563,7 @@ describe('Test log-core', function () {
         });
 
         it('Test preparing a stacktrace exceeding size limitation', function () {
-            var stack = [...Array(10000).keys()].reduce((p, c) => { return p + "line" + c + "\n"}, "").trim()
+            var stack = [...Array(10000).keys()].reduce((p, c) => { return p + "line" + c + "\n" }, "").trim()
             var arr = prepareStacktrace(stack)
             arr.length.should.equal(7171)
             arr[0].should.equal("-------- STACK TRACE TRUNCATED --------")
@@ -659,7 +659,7 @@ describe('Test log-core', function () {
             output.should.equal(JSON.stringify(data) + os.EOL);
         });
 
-        it("Test  log writing in pattern mode with correct keys", function () {
+        it("Test log writing in pattern mode with correct keys", function () {
             var data = {
                 text: "abc",
                 number: 21,
@@ -673,7 +673,7 @@ describe('Test log-core', function () {
             output.should.equal('Test: abc 21 ' + JSON.stringify(data.obj) + os.EOL);
         });
 
-        it("Test  log writing in pattern mode with non-existing keys", function () {
+        it("Test log writing in pattern mode with non-existing keys", function () {
             var data = {
                 text: "abc",
                 number: 21,
@@ -749,7 +749,7 @@ describe('Test log-core', function () {
             level.should.equal("warn");
         });
 
-        it("Test  log writing in pattern mode with correct keys to custom log sink", function () {
+        it("Test log writing in pattern mode with correct keys to custom log sink", function () {
             var data = {
                 text: "abc",
                 number: 21,
@@ -1104,7 +1104,7 @@ describe('Test log-core', function () {
 
             // check correlation id inheritance
             logger1.getCorrelationId().should.equal(req.logger.getCorrelationId());
-            
+
             // set a new correlation id using logger2
             logger2.setCorrelationId(uuid());
 
@@ -1132,7 +1132,7 @@ describe('Test log-core', function () {
                 } else {
                     assert.isFunction(logger[lvl]);
                     logger[lvl]("test");
-                    level.should.equal(lvl);   
+                    level.should.equal(lvl);
                 }
             }
         });
@@ -1247,13 +1247,13 @@ describe('Test log-core', function () {
             registerCustomFields = core.registerCustomFields;
             setCustomFields = core.setCustomFields;
             overrideCustomFieldFormat = core.overrideCustomFieldFormat;
-            process.hrtime = function (){
-                    return [this.hrHigh, this.hrLow];
-                }
-            process.setHrTime = function (high, low){
-                    this.hrHigh = high;
-                    this.hrLow = low;
-                }
+            process.hrtime = function () {
+                return [this.hrHigh, this.hrLow];
+            }
+            process.setHrTime = function (high, low) {
+                this.hrHigh = high;
+                this.hrLow = low;
+            }
         });
 
         beforeEach(function () {
@@ -1264,39 +1264,39 @@ describe('Test log-core', function () {
 
         it('Test normal', function () {
             //tests behaviour for reasonable timestamps
-            process.setHrTime(1,1000);
-            log("info","test");
+            process.setHrTime(1, 1000);
+            log("info", "test");
             var time1 = logObject.written_ts;
-            process.setHrTime(1,2000);
-            log("info","test");
+            process.setHrTime(1, 2000);
+            log("info", "test");
             var time2 = logObject.written_ts;
-            assert.isBelow(time1,time2);
+            assert.isBelow(time1, time2);
         });
 
         it('Test overflow', function () {
             //testing hrtime overflow behaviour
-            process.setHrTime(1,999000);
-            log("info","test");
+            process.setHrTime(1, 999000);
+            log("info", "test");
             var time1 = logObject.written_ts;
-            process.setHrTime(1,1000000);
-            log("info","test");
+            process.setHrTime(1, 1000000);
+            log("info", "test");
             var time2 = logObject.written_ts;
-            assert.isBelow(time1,time2);
+            assert.isBelow(time1, time2);
         });
 
         it('Test small incremental', function () {
             //small incremental may result in the same timestamp
             //this makes sure that they are at least the same or correct
-            process.setHrTime(1,1001);
-            log("info","test");
+            process.setHrTime(1, 1001);
+            log("info", "test");
             var time1 = logObject.written_ts;
-            process.setHrTime(1,1002);
-            log("info","test");
+            process.setHrTime(1, 1002);
+            log("info", "test");
             var time2 = logObject.written_ts;
-            process.setHrTime(1,1003);
-            log("info","test");
+            process.setHrTime(1, 1003);
+            log("info", "test");
             var time3 = logObject.written_ts;
-            assert.isAtLeast(time3,time2);
+            assert.isAtLeast(time3, time2);
         });
     })
 
@@ -1384,7 +1384,7 @@ describe('Test log-core', function () {
         });
     });
 
-    describe("Test custom field logic", function() {
+    describe("Test custom field logic", function () {
         var core = rewire("../core/log-core.js");
 
         var logObject = null;
@@ -1410,7 +1410,7 @@ describe('Test log-core', function () {
             overrideCustomFieldFormat("default");
             registerCustomFields({});
         });
-        
+
         it("Test custom fields log output (number)", function () {
             log("info", "Test", 42);
 
@@ -1429,8 +1429,8 @@ describe('Test log-core', function () {
             });
             logObject.msg.should.equal('Test');
             logObject["#cf"].string.should.eql([
-                {"k":"fieldA","v":"valueA","i":0},
-                {"k":"fieldC","v":"valueC","i":1}
+                { "k": "fieldA", "v": "valueA", "i": 0 },
+                { "k": "fieldC", "v": "valueC", "i": 1 }
             ]);
         });
 
@@ -1447,7 +1447,7 @@ describe('Test log-core', function () {
             logObject.msg.should.equal('Test');
             logObject.layer.should.equal('testLayer');
             logObject["#cf"].string.should.eql([
-                {"k":"fieldA","v":"valueA","i":0}
+                { "k": "fieldA", "v": "valueA", "i": 0 }
             ]);
         });
 
@@ -1456,7 +1456,7 @@ describe('Test log-core', function () {
             overrideCustomFieldFormat("application-logging");
             registerCustomFields(["fieldA", "fieldC"]);
 
-            log("info", "Test", {"layer":"test-layer", "logger":"test-logger"});
+            log("info", "Test", { "layer": "test-layer", "logger": "test-logger" });
             logObject.msg.should.equal('Test');
 
             assert.equal(logObject["#cf"], null);
@@ -1472,9 +1472,9 @@ describe('Test log-core', function () {
 
             logObject.msg.should.equal('Test');
             logObject["#cf"].string.should.eql([
-                {"k":"0","v":"1","i":0},
-                {"k":"1","v":"123","i":1},
-                {"k":"2","v":"{\"field\":\"values\"}","i":2}
+                { "k": "0", "v": "1", "i": 0 },
+                { "k": "1", "v": "123", "i": 1 },
+                { "k": "2", "v": "{\"field\":\"values\"}", "i": 2 }
             ]);
         });
 
@@ -1483,10 +1483,10 @@ describe('Test log-core', function () {
             overrideCustomFieldFormat("all");
 
             log("info", "Test", {
-                    "a": "string",
-                    "b": 1337,
-                    "c": {"nested":"object"}
-                }
+                "a": "string",
+                "b": 1337,
+                "c": { "nested": "object" }
+            }
             );
 
             logObject.msg.should.equal('Test');
@@ -1494,9 +1494,9 @@ describe('Test log-core', function () {
             logObject.b.should.equal("1337");
             logObject.c.should.equal("{\"nested\":\"object\"}");
             logObject["#cf"].string.should.eql([
-                {"k":"a","v":"string","i":0},
-                {"k":"b","v":"1337","i":1},
-                {"k":"c","v":"{\"nested\":\"object\"}","i":2}
+                { "k": "a", "v": "string", "i": 0 },
+                { "k": "b", "v": "1337", "i": 1 },
+                { "k": "c", "v": "{\"nested\":\"object\"}", "i": 2 }
             ]);
         });
 
@@ -1505,10 +1505,10 @@ describe('Test log-core', function () {
             overrideCustomFieldFormat("default");
 
             log("info", "Test", {
-                    "a": "string",
-                    "b": 1337,
-                    "c": {"nested":"object"}
-                }
+                "a": "string",
+                "b": 1337,
+                "c": { "nested": "object" }
+            }
             );
 
             logObject.msg.should.equal('Test');
@@ -1522,10 +1522,10 @@ describe('Test log-core', function () {
             overrideCustomFieldFormat("default");
 
             log("info", "Test", {
-                    "a": "string",
-                    "b": 1337,
-                    "c": {"nested":"object"}
-                }
+                "a": "string",
+                "b": 1337,
+                "c": { "nested": "object" }
+            }
             );
 
             logObject.msg.should.equal('Test');
@@ -1540,10 +1540,10 @@ describe('Test log-core', function () {
             overrideCustomFieldFormat("disabled");
 
             log("info", "Test", {
-                    "a": "string",
-                    "b": 1337,
-                    "c": {"nested":"object"}
-                }
+                "a": "string",
+                "b": 1337,
+                "c": { "nested": "object" }
+            }
             );
 
             logObject.msg.should.equal('Test');
@@ -1554,22 +1554,22 @@ describe('Test log-core', function () {
         });
 
         it("Test reading bindings from context", function () {
-                process.env.VCAP_SERVICES = JSON.stringify({
-                    "application-logs": [
-                        {"plan": "lite"}
-                    ],
-                    "cloud-logs": [
-                        {"plan": "lite"}
-                    ]
-                })
-                core.init();
+            process.env.VCAP_SERVICES = JSON.stringify({
+                "application-logs": [
+                    { "plan": "lite" }
+                ],
+                "cloud-logs": [
+                    { "plan": "lite" }
+                ]
+            })
+            core.init();
             registerCustomFields(["a", "b", "c"]);
 
             log("info", "Test", {
-                    "a": "string",
-                    "b": 1337,
-                    "c": {"nested":"object"}
-                }
+                "a": "string",
+                "b": 1337,
+                "c": { "nested": "object" }
+            }
             );
 
             logObject.msg.should.equal('Test');
@@ -1577,30 +1577,30 @@ describe('Test log-core', function () {
             logObject.b.should.equal("1337");
             logObject.c.should.equal("{\"nested\":\"object\"}");
             logObject["#cf"].string.should.eql([
-                {"k":"a","v":"string","i":0},
-                {"k":"b","v":"1337","i":1},
-                {"k":"c","v":"{\"nested\":\"object\"}","i":2}
+                { "k": "a", "v": "string", "i": 0 },
+                { "k": "b", "v": "1337", "i": 1 },
+                { "k": "c", "v": "{\"nested\":\"object\"}", "i": 2 }
             ]);
         });
 
         it("Test faulty binding string defaulting", function () {
             process.env.VCAP_SERVICES = '{"application-logs": [{"plan": "lite"}],"cloud-logs": [{"plan": "lite"}]'
             core.init();
-        registerCustomFields(["a", "b", "c"]);
+            registerCustomFields(["a", "b", "c"]);
 
-        log("info", "Test", {
+            log("info", "Test", {
                 "a": "string",
                 "b": 1337,
-                "c": {"nested":"object"}
+                "c": { "nested": "object" }
             }
-        );
+            );
 
-        logObject.msg.should.equal('Test');
-        logObject.a.should.equal("string");
-        logObject.b.should.equal("1337");
-        logObject.c.should.equal("{\"nested\":\"object\"}");
-        assert.equal(logObject["#cf"], null);
-    });
+            logObject.msg.should.equal('Test');
+            logObject.a.should.equal("string");
+            logObject.b.should.equal("1337");
+            logObject.c.should.equal("{\"nested\":\"object\"}");
+            assert.equal(logObject["#cf"], null);
+        });
 
         it("Test custom fields inheritance", function () {
             // Register fields
@@ -1627,8 +1627,8 @@ describe('Test log-core', function () {
 
 
             logObject["#cf"].string.should.eql([
-                {"k":"fieldA","v":"a","i":0},
-                {"k":"fieldB","v":"b","i":1},
+                { "k": "fieldA", "v": "a", "i": 0 },
+                { "k": "fieldB", "v": "b", "i": 1 },
             ]);
 
             // loggerA fields and non-overwritten global fields
@@ -1636,25 +1636,25 @@ describe('Test log-core', function () {
             logObject.msg.should.equal('Test');
 
             logObject["#cf"].string.should.eql([
-                {"k":"fieldA","v":"c","i":0},
-                {"k":"fieldB","v":"b","i":1},
+                { "k": "fieldA", "v": "c", "i": 0 },
+                { "k": "fieldB", "v": "b", "i": 1 },
             ]);
 
             // loggerB fields and inherited loggerA and global fields
             loggerB.logMessage("info", "Test", {});
             logObject.msg.should.equal('Test');
             logObject["#cf"].string.should.eql([
-                {"k":"fieldA","v":"d","i":0},
-                {"k":"fieldB","v":"b","i":1},
-                {"k":"fieldC","v":"c","i":2},
+                { "k": "fieldA", "v": "d", "i": 0 },
+                { "k": "fieldB", "v": "b", "i": 1 },
+                { "k": "fieldC", "v": "c", "i": 2 },
             ]);
 
             // inherited loggerA/global fields and NOT unknown field 'fieldU'
             loggerC.logMessage("info", "Test", {});
             logObject.msg.should.equal('Test');
             logObject["#cf"].string.should.eql([
-                {"k":"fieldA","v":"c","i":0},
-                {"k":"fieldB","v":"b","i":1},
+                { "k": "fieldA", "v": "c", "i": 0 },
+                { "k": "fieldB", "v": "b", "i": 1 },
             ]);
         });
 
@@ -1699,7 +1699,7 @@ describe('Test log-core', function () {
             log("info", "Test", obj);
 
             logObject["#cf"].string.should.eql([
-                {"k":"fieldA","v":"{\"a\":456,\"b\":{\"b\":123,\"a\":\"[Circular ~]\"}}","i":0}
+                { "k": "fieldA", "v": "{\"a\":456,\"b\":{\"b\":123,\"a\":\"[Circular ~]\"}}", "i": 0 }
             ]);
         });
 
@@ -1729,9 +1729,9 @@ describe('Test log-core', function () {
             logObject.msg.should.equal('Test abc');
 
             logObject["#cf"].string.should.eql([
-                {"k":"string","v":"text","i":0},
-                {"k":"int","v":"0","i":1},
-                {"k":"obj","v":"{\"test\":\"value\"}","i":2}
+                { "k": "string", "v": "text", "i": 0 },
+                { "k": "int", "v": "0", "i": 1 },
+                { "k": "obj", "v": "{\"test\":\"value\"}", "i": 2 }
             ]);
         });
 
@@ -1739,16 +1739,16 @@ describe('Test log-core', function () {
             registerCustomFields(["1", "2", "3"]);
             overrideCustomFieldFormat("application-logging");
 
-            log("info","Test order", {
+            log("info", "Test order", {
                 "1": "1",
                 "3": "3",
                 "2": "2"
             });
 
             logObject["#cf"].string.should.eql([
-                {"k":"1","v":"1","i":0},
-                {"k":"2","v":"2","i":1},
-                {"k":"3","v":"3","i":2}
+                { "k": "1", "v": "1", "i": 0 },
+                { "k": "2", "v": "2", "i": 1 },
+                { "k": "3", "v": "3", "i": 2 }
             ]);
         });
 
@@ -1756,14 +1756,14 @@ describe('Test log-core', function () {
             registerCustomFields(["1", "2", "3"]);
             overrideCustomFieldFormat("application-logging");
 
-            log("info","Test order", {
+            log("info", "Test order", {
                 "1": "1",
                 "3": "3"
             });
 
             logObject["#cf"].string.should.eql([
-                {"k":"1","v":"1","i":0},
-                {"k":"3","v":"3","i":2}
+                { "k": "1", "v": "1", "i": 0 },
+                { "k": "3", "v": "3", "i": 2 }
             ]);
         });
 
@@ -1782,7 +1782,7 @@ describe('Test log-core', function () {
 
             logObject.msg.should.equal('Test abc');
             logObject["#cf"].string.should.eql([
-                {"k":"int","v":"0","i":0}
+                { "k": "int", "v": "0", "i": 0 }
             ]);
         });
 
@@ -1880,7 +1880,7 @@ describe('Test log-core', function () {
 
         before(function () {
             // set clock to 2017-01-01T00:00:00.000Z
-            clock = sinon.useFakeTimers({now: 1483228800000});
+            clock = sinon.useFakeTimers({ now: 1483228800000 });
         });
 
         beforeEach(function () {


### PR DESCRIPTION
- Add support for logging stack traces
  - When providing an `Error` object to any of our logging methods the corresponding stack trace gets written to the `stacktrace` field. E.g.:
    ```js
    try {
      // Code throwing an Error
    } catch (e) {
      logger.error("Error occurred", e)
    }
    // ... "msg":"Error occurred", "stacktrace": [...] ...
    ```
  - `Error` objects get detected using duck typing. There does not seem to be a better solution for detecting `Error` objects at the moment.
  - Very large stack traces (> 55kB) get truncated using following strategy:
    - Take one line from the top and two lines from the bottom of the stacktrace until limit is reached.
    - This strategy is similar to the approach used in cf-java-logging-support.
- Add unit tests
- Add documentation
- Fix code and documentation format 