### PR TITLE
Add stacktrace and custom fields logging

### DIFF
--- a/v2/cf-nodejs-logging-support/package-lock.json
+++ b/v2/cf-nodejs-logging-support/package-lock.json
@@ -13,6 +13,7 @@
         "connect": "^3.7.0",
         "express": "^4.17.3",
         "http": "^0.0.1-security",
+        "json-stringify-safe": "^5.0.1",
         "restify": "^8.6.1"
       },
       "devDependencies": {
@@ -2892,6 +2893,11 @@
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
       "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
       "dev": true
+    },
+    "node_modules/json-stringify-safe": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
     },
     "node_modules/jsonc-parser": {
       "version": "3.0.0",
@@ -7328,6 +7334,11 @@
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
       "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
       "dev": true
+    },
+    "json-stringify-safe": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
     },
     "jsonc-parser": {
       "version": "3.0.0",

--- a/v2/cf-nodejs-logging-support/package.json
+++ b/v2/cf-nodejs-logging-support/package.json
@@ -64,6 +64,7 @@
     "connect": "^3.7.0",
     "express": "^4.17.3",
     "http": "^0.0.1-security",
+    "json-stringify-safe": "^5.0.1",
     "restify": "^8.6.1"
   }
 }

--- a/v2/cf-nodejs-logging-support/src/lib/config/config-schema.json
+++ b/v2/cf-nodejs-logging-support/src/lib/config/config-schema.json
@@ -5,9 +5,6 @@
         "ConfigField": {
             "additionalProperties": false,
             "properties": {
-                "context": {
-                    "type": "boolean"
-                },
                 "default": {
                     "type": "string"
                 },

--- a/v2/cf-nodejs-logging-support/src/lib/config/config.ts
+++ b/v2/cf-nodejs-logging-support/src/lib/config/config.ts
@@ -165,25 +165,8 @@ export default class Config {
         Config.instance.config.outputStartupMsg = enabled;
     }
 
-    // delete framework specific fields that are not supported
-    public compressFields(framework: framework): void {
-        Config.instance.config.fields!.forEach(field => {
-            if (field.source && Array.isArray(field.source) && field.source.length > 0) {
-                let i = 0
-                while (i < field.source.length) {
-                    if (field.source[i].framework !== undefined && !field.source[i].framework!.includes(framework)) {
-                        field.source.shift();
-                    } else {
-                        i++;
-                    }
-                }
-            }
-        });
-    }
-
     public setFramework(framework: framework): void {
         Config.instance.config.framework = framework;
-        Config.instance.compressFields(framework);
     }
 
     // get index of field in config

--- a/v2/cf-nodejs-logging-support/src/lib/config/config.ts
+++ b/v2/cf-nodejs-logging-support/src/lib/config/config.ts
@@ -181,6 +181,11 @@ export default class Config {
         });
     }
 
+    public setFramework(framework: framework): void {
+        Config.instance.config.framework = framework;
+        Config.instance.compressFields(framework);
+    }
+
     // get index of field in config
     private getIndex(name: string): number {
 

--- a/v2/cf-nodejs-logging-support/src/lib/logger/context.ts
+++ b/v2/cf-nodejs-logging-support/src/lib/logger/context.ts
@@ -27,11 +27,15 @@ export default class ReqContext {
             if (!Array.isArray(field.source)) {
                 this.properties[field.name] = this.getPropValue(field.source, req);
             } else {
-                let sourceIndex = SourceUtils.getNextValidSourceIndex(field.source);
-                while (!this.properties[field.name] && sourceIndex != -1) {
+                let sourceIndex = 0;
+                while (!this.properties[field.name]) {
+                    sourceIndex = SourceUtils.getNextValidSourceIndex(field.source, sourceIndex);
+                    if (sourceIndex == -1) {
+                        return;
+                    }
                     let source = field.source[sourceIndex];
                     this.properties[field.name] = this.getPropValue(source, req);
-                    sourceIndex = SourceUtils.getNextValidSourceIndex(field.source, ++sourceIndex);
+                    ++sourceIndex;
                 }
             }
         });

--- a/v2/cf-nodejs-logging-support/src/lib/logger/logger.ts
+++ b/v2/cf-nodejs-logging-support/src/lib/logger/logger.ts
@@ -40,9 +40,7 @@ export default class Logger {
 
     logMessage(levelName: string, ..._args: any) {
         if (!this.isLoggingLevel(levelName)) return;
-        const record = this.context ?
-            RecordFactory.buildMsgRecord(this.registeredCustomFields, this.customFields, levelName, _args, this.context)
-            : RecordFactory.buildMsgRecord(this.registeredCustomFields, this.customFields, levelName, _args);
+        const record = RecordFactory.buildMsgRecord(this.registeredCustomFields, this.customFields, levelName, _args, this.context);
         RecordWriter.getInstance().writeLog(record);
     }
 

--- a/v2/cf-nodejs-logging-support/src/lib/logger/logger.ts
+++ b/v2/cf-nodejs-logging-support/src/lib/logger/logger.ts
@@ -40,7 +40,7 @@ export default class Logger {
 
     logMessage(levelName: string, ..._args: any) {
         if (!this.isLoggingLevel(levelName)) return;
-        const record = RecordFactory.buildMsgRecord(this.registeredCustomFields, this.customFields, levelName, _args, this.context);
+        const record = RecordFactory.getInstance().buildMsgRecord(this.registeredCustomFields, this.customFields, levelName, _args, this.context);
         RecordWriter.getInstance().writeLog(record);
     }
 

--- a/v2/cf-nodejs-logging-support/src/lib/logger/logger.ts
+++ b/v2/cf-nodejs-logging-support/src/lib/logger/logger.ts
@@ -39,7 +39,7 @@ export default class Logger {
 
     logMessage(levelName: string, ..._args: any) {
         if (!this.isLoggingLevel(levelName)) return;
-        const record = this.context ? RecordFactory.buildMsgRecord(_args, this.context) : RecordFactory.buildMsgRecord(_args);
+        const record = this.context ? RecordFactory.buildMsgRecord(levelName, _args, this.context) : RecordFactory.buildMsgRecord(levelName, _args);
         RecordWriter.getInstance().writeLog(record);
     }
 

--- a/v2/cf-nodejs-logging-support/src/lib/logger/logger.ts
+++ b/v2/cf-nodejs-logging-support/src/lib/logger/logger.ts
@@ -39,7 +39,9 @@ export default class Logger {
 
     logMessage(levelName: string, ..._args: any) {
         if (!this.isLoggingLevel(levelName)) return;
-        const record = this.context ? RecordFactory.buildMsgRecord(levelName, _args, this.context) : RecordFactory.buildMsgRecord(levelName, _args);
+        const record = this.context ?
+            RecordFactory.buildMsgRecord(this.customFields, levelName, _args, this.context)
+            : RecordFactory.buildMsgRecord(this.customFields, levelName, _args);
         RecordWriter.getInstance().writeLog(record);
     }
 

--- a/v2/cf-nodejs-logging-support/src/lib/logger/logger.ts
+++ b/v2/cf-nodejs-logging-support/src/lib/logger/logger.ts
@@ -64,5 +64,6 @@ export default class Logger {
 
     initContext(_req: any) {
         this.context = new ReqContext(_req);
+        return this.context;
     }
 }

--- a/v2/cf-nodejs-logging-support/src/lib/logger/logger.ts
+++ b/v2/cf-nodejs-logging-support/src/lib/logger/logger.ts
@@ -7,6 +7,7 @@ import ReqContext from "./context";
 export default class Logger {
     private parent?: Logger = undefined
     private context?: ReqContext;
+    private registeredCustomFields: Array<string> = [];
     private customFields: Map<string, any> = new Map<string, any>()
     protected loggingLevelThreshold: Level = Level.INHERIT
 
@@ -40,9 +41,13 @@ export default class Logger {
     logMessage(levelName: string, ..._args: any) {
         if (!this.isLoggingLevel(levelName)) return;
         const record = this.context ?
-            RecordFactory.buildMsgRecord(this.customFields, levelName, _args, this.context)
-            : RecordFactory.buildMsgRecord(this.customFields, levelName, _args);
+            RecordFactory.buildMsgRecord(this.registeredCustomFields, this.customFields, levelName, _args, this.context)
+            : RecordFactory.buildMsgRecord(this.registeredCustomFields, this.customFields, levelName, _args);
         RecordWriter.getInstance().writeLog(record);
+    }
+
+    registerCustomFields(fieldNames: Array<string>) {
+        this.registeredCustomFields = fieldNames;
     }
 
     setCustomFields(customFields: Map<string, any>) {

--- a/v2/cf-nodejs-logging-support/src/lib/logger/record-factory.ts
+++ b/v2/cf-nodejs-logging-support/src/lib/logger/record-factory.ts
@@ -11,7 +11,7 @@ export default class RecordFactory {
     static MAX_STACKTRACE_SIZE = 55 * 1024;
 
     // init a new record and assign fields with output "msg-log"
-    static buildMsgRecord(loggerCustomFields: Map<string, any>, level: string, args: Array<any>, context?: ReqContext): any {
+    static buildMsgRecord(registeredCustomFields: Array<string>, loggerCustomFields: Map<string, any>, level: string, args: Array<any>, context?: ReqContext): any {
 
         let record: any = {
             "level": level,
@@ -48,7 +48,7 @@ export default class RecordFactory {
             }
         }
 
-        record = this.addCustomFields(record, loggerCustomFields, customFieldsFromArgs);
+        record = this.addCustomFields(record, registeredCustomFields, loggerCustomFields, customFieldsFromArgs);
         record["msg"] = util.format.apply(util, args);
         return record;
     }
@@ -172,7 +172,7 @@ export default class RecordFactory {
         return true;
     }
 
-    private static addCustomFields(record: any, loggerCustomFields: Map<string, any>, customFieldsFromArgs: any): any {
+    private static addCustomFields(record: any, registeredCustomFields: Array<string>, loggerCustomFields: Map<string, any>, customFieldsFromArgs: any): any {
         var providedFields = Object.assign({}, loggerCustomFields, customFieldsFromArgs);
         const customFieldsFormat = Config.getInstance().getConfig().customFieldsFormat;
 
@@ -184,29 +184,26 @@ export default class RecordFactory {
                 value = stringifySafe(value);
             }
 
-            // let customFields: any = {};
-            if (customFieldsFormat == "application-logging" || record[key] != null) {
+            if (customFieldsFormat == "cloud-logging" || record[key] != null) {
                 record[key] = value;
             }
-            // if (customFieldsFormat == "cloud-logging")
-            //     customFields[key] = value;
         }
 
-        if (customFieldsFormat == "cloud-logging") {
-            // let res: any = {};
-            // res.string = [];
-            // let key;
-            // for (var i = 0; i < registeredCustomFields.length; i++) {
-            //     key = registeredCustomFields[i]
-            //     if (providedFields[key])
-            //         res.string.push({
-            //             "k": key,
-            //             "v": providedFields[key],
-            //             "i": i
-            //         })
-            // }
-            // if (res.string.length > 0)
-            //     record["#cf"] = res;
+        if (customFieldsFormat == "application-logging") {
+            let res: any = {};
+            res.string = [];
+            let key;
+            for (var i = 0; i < registeredCustomFields.length; i++) {
+                key = registeredCustomFields[i]
+                if (providedFields[key])
+                    res.string.push({
+                        "k": key,
+                        "v": providedFields[key],
+                        "i": i
+                    })
+            }
+            if (res.string.length > 0)
+                record["#cf"] = res;
         }
         return record;
     }

--- a/v2/cf-nodejs-logging-support/src/lib/logger/record-factory.ts
+++ b/v2/cf-nodejs-logging-support/src/lib/logger/record-factory.ts
@@ -167,6 +167,8 @@ export default class RecordFactory {
     private static addCustomFields(record: any, registeredCustomFields: Array<string>, loggerCustomFields: Map<string, any>, customFieldsFromArgs: any): any {
         var providedFields = Object.assign({}, loggerCustomFields, customFieldsFromArgs);
         const customFieldsFormat = Config.getInstance().getConfig().customFieldsFormat;
+        const isCloudLogging = customFieldsFormat == "cloud-logging";
+        const isAppLogging = customFieldsFormat == "application-logging";
 
         for (var key in providedFields) {
             var value = providedFields[key];
@@ -176,12 +178,12 @@ export default class RecordFactory {
                 value = stringifySafe(value);
             }
 
-            if (customFieldsFormat == "cloud-logging" || record[key] != null) {
+            if (isCloudLogging || record[key] != null) {
                 record[key] = value;
             }
         }
 
-        if (customFieldsFormat == "application-logging") {
+        if (isAppLogging) {
             let res: any = {};
             res.string = [];
             let key;

--- a/v2/cf-nodejs-logging-support/src/lib/logger/record-factory.ts
+++ b/v2/cf-nodejs-logging-support/src/lib/logger/record-factory.ts
@@ -1,9 +1,5 @@
 import util from "util";
 import Config from "../config/config";
-import { ConfigField, Source } from "../config/interfaces";
-import NestedVarResolver from "../helper/nested-var-resolver";
-import RequestAccessor from "../middleware/request-Accessor";
-import ResponseAccessor from "../middleware/response-accessor";
 import ReqContext from "./context";
 import { SourceUtils } from "./source-utils";
 const stringifySafe = require('json-stringify-safe');

--- a/v2/cf-nodejs-logging-support/src/lib/logger/record-factory.ts
+++ b/v2/cf-nodejs-logging-support/src/lib/logger/record-factory.ts
@@ -175,8 +175,6 @@ export default class RecordFactory {
     private addCustomFields(record: any, registeredCustomFields: Array<string>, loggerCustomFields: Map<string, any>, customFieldsFromArgs: any): any {
         var providedFields = Object.assign({}, loggerCustomFields, customFieldsFromArgs);
         const customFieldsFormat = Config.getInstance().getConfig().customFieldsFormat;
-        const isCloudLogging = customFieldsFormat == "cloud-logging";
-        const isAppLogging = customFieldsFormat == "application-logging";
 
         for (var key in providedFields) {
             var value = providedFields[key];
@@ -186,12 +184,12 @@ export default class RecordFactory {
                 value = stringifySafe(value);
             }
 
-            if (isCloudLogging || record[key] != null) {
+            if (customFieldsFormat == "cloud-logging" || record[key] != null) {
                 record[key] = value;
             }
         }
 
-        if (isAppLogging) {
+        if (customFieldsFormat == "application-logging") {
             let res: any = {};
             res.string = [];
             let key;

--- a/v2/cf-nodejs-logging-support/src/lib/logger/record-factory.ts
+++ b/v2/cf-nodejs-logging-support/src/lib/logger/record-factory.ts
@@ -51,11 +51,15 @@ export default class RecordFactory {
             if (!Array.isArray(field.source)) {
                 record[field.name] = this.getFieldValue(field.source, record);
             } else {
-                let sourceIndex = SourceUtils.getNextValidSourceIndex(field.source);
-                while (!record[field.name] && sourceIndex != -1) {
+                let sourceIndex = 0;
+                while (!record[field.name]) {
+                    sourceIndex = SourceUtils.getNextValidSourceIndex(field.source, sourceIndex);
+                    if (sourceIndex == -1) {
+                        return;
+                    }
                     let source = field.source[sourceIndex];
                     record[field.name] = this.getFieldValue(source, record);
-                    sourceIndex = SourceUtils.getNextValidSourceIndex(field.source, ++sourceIndex);
+                    ++sourceIndex;
                 }
             }
         });
@@ -86,11 +90,15 @@ export default class RecordFactory {
                     record[field.name] = this.getFieldValue(field.source, record);
                 }
             } else {
-                let sourceIndex = SourceUtils.getNextValidSourceIndex(field.source);
-                while (!record[field.name] && sourceIndex != -1) {
+                let sourceIndex = 0;
+                while (!record[field.name]) {
+                    sourceIndex = SourceUtils.getNextValidSourceIndex(field.source, sourceIndex);
+                    if (sourceIndex == -1) {
+                        return;
+                    }
                     let source = field.source[sourceIndex];
                     record[field.name] = this.getReqFieldValue(source, record, requestAccessor, responseAccessor, req, res);
-                    sourceIndex = SourceUtils.getNextValidSourceIndex(field.source, ++sourceIndex);
+                    ++sourceIndex;
                 }
             }
         });

--- a/v2/cf-nodejs-logging-support/src/lib/logger/record-factory.ts
+++ b/v2/cf-nodejs-logging-support/src/lib/logger/record-factory.ts
@@ -24,7 +24,6 @@ export default class RecordFactory {
         var customFieldsFromArgs = {};
         var lastArg = args[args.length - 1];
 
-        // why check if lastArg and lastArg._error?
         if (typeof lastArg === "object") {
             if (RecordFactory.isErrorWithStacktrace(lastArg)) {
                 record.stacktrace = RecordFactory.prepareStacktrace(lastArg.stack);

--- a/v2/cf-nodejs-logging-support/src/lib/logger/root-logger.ts
+++ b/v2/cf-nodejs-logging-support/src/lib/logger/root-logger.ts
@@ -1,5 +1,5 @@
 import Config from "../config/config"
-import { ConfigObject, customFieldsFormat } from "../config/interfaces"
+import { ConfigObject, customFieldsFormat, framework } from "../config/interfaces"
 import EnvService from "../core/env-service";
 import Level from "./level"
 import Logger from "./logger"
@@ -64,6 +64,7 @@ export default class RootLogger extends Logger {
     overrideCustomFieldFormat(value: string) { }
     setLogPattern() { }
     createWinstonTransport() { }
-    forceLogger(logger: string) {
+    forceLogger(logger: framework) {
+        Config.getInstance().setFramework(logger);
     }
 }

--- a/v2/cf-nodejs-logging-support/src/lib/logger/root-logger.ts
+++ b/v2/cf-nodejs-logging-support/src/lib/logger/root-logger.ts
@@ -53,7 +53,10 @@ export default class RootLogger extends Logger {
         Middleware.logNetwork(req, res, next);
     }
 
-    registerCustomFields(object: Object) { }
+    registerCustomFields(fieldNames: Array<string>) {
+        // registeredCustomFields = JSON.parse(JSON.stringify(fieldNames));
+        return true;
+    }
 
     getBoundServices() {
         return EnvService.getBoundServices()

--- a/v2/cf-nodejs-logging-support/src/lib/logger/root-logger.ts
+++ b/v2/cf-nodejs-logging-support/src/lib/logger/root-logger.ts
@@ -53,11 +53,6 @@ export default class RootLogger extends Logger {
         Middleware.logNetwork(req, res, next);
     }
 
-    registerCustomFields(fieldNames: Array<string>) {
-        // registeredCustomFields = JSON.parse(JSON.stringify(fieldNames));
-        return true;
-    }
-
     getBoundServices() {
         return EnvService.getBoundServices()
     }

--- a/v2/cf-nodejs-logging-support/src/lib/logger/source-utils.ts
+++ b/v2/cf-nodejs-logging-support/src/lib/logger/source-utils.ts
@@ -3,9 +3,9 @@ import { Source } from "../config/interfaces";
 
 export class SourceUtils {
     // returns -1 when all sources were iterated
-    static getNextValidSourceIndex(sources: Source[], startIndex?: number): number {
+    static getNextValidSourceIndex(sources: Source[], startIndex: number): number {
         const framework = Config.getInstance().getFramework();
-        var i: number = startIndex ? startIndex : 0;
+        var i: number = startIndex;
 
         for (i; i < sources.length; i++) {
             if (!sources[i].framework) {

--- a/v2/cf-nodejs-logging-support/src/lib/logger/source-utils.ts
+++ b/v2/cf-nodejs-logging-support/src/lib/logger/source-utils.ts
@@ -79,7 +79,8 @@ export class SourceUtils {
         field.source = field.source as Source[];
 
         let sourceIndex = 0;
-        while (!record[field.name]) {
+        let fieldValue;
+        while (fieldValue == null) {
             sourceIndex = SourceUtils.getInstance().getNextValidSourceIndex(field.source, sourceIndex);
 
             if (sourceIndex == -1) {
@@ -88,13 +89,13 @@ export class SourceUtils {
 
             let source = field.source[sourceIndex];
 
-            record[field.name] = origin == "msg-log" ? this.getFieldValue(source, record) :
+            fieldValue = origin == "msg-log" ? this.getFieldValue(source, record) :
                 origin == "req-log" ? this.getReqFieldValue(source, record, req, res) :
                     this.getContextFieldValue(source, req);
 
             ++sourceIndex;
         }
-        return record[field.name];
+        return fieldValue;
     }
 
     // returns -1 when all sources were iterated

--- a/v2/cf-nodejs-logging-support/src/lib/logger/source-utils.ts
+++ b/v2/cf-nodejs-logging-support/src/lib/logger/source-utils.ts
@@ -100,9 +100,8 @@ export class SourceUtils {
     // returns -1 when all sources were iterated
     private getNextValidSourceIndex(sources: Source[], startIndex: number): number {
         const framework = Config.getInstance().getFramework();
-        var i: number = startIndex;
 
-        for (i; i < sources.length; i++) {
+        for (let i = startIndex; i < sources.length; i++) {
             if (!sources[i].framework) {
                 return i;
             }

--- a/v2/cf-nodejs-logging-support/src/lib/logger/source-utils.ts
+++ b/v2/cf-nodejs-logging-support/src/lib/logger/source-utils.ts
@@ -1,9 +1,104 @@
 import Config from "../config/config";
-import { Source } from "../config/interfaces";
+import { ConfigField, Source } from "../config/interfaces";
+import NestedVarResolver from "../helper/nested-var-resolver";
+import RequestAccessor from "../middleware/request-Accessor";
+import ResponseAccessor from "../middleware/response-accessor";
+const { v4: uuid } = require('uuid');
+
+type origin = "msg-log" | "req-log" | "context";
 
 export class SourceUtils {
+    private static instance: SourceUtils;
+    private requestAccessor: RequestAccessor = RequestAccessor.getInstance();
+    private responseAccessor = ResponseAccessor.getInstance();
+
+    private constructor() { }
+
+    public static getInstance(): SourceUtils {
+        if (!SourceUtils.instance) {
+            SourceUtils.instance = new SourceUtils();
+        }
+
+        return SourceUtils.instance;
+    }
+
+    getFieldValue(source: Source, record: any): string | undefined {
+        switch (source.type) {
+            case "static":
+                return source.value;
+            case "env":
+                if (source.path) {
+                    return NestedVarResolver.resolveNestedVariable(process.env, source.path);
+                }
+                return process.env[source.name!];
+            case "config-field":
+                return record[source.name!];
+            default:
+                return undefined;
+        }
+    }
+
+    getReqFieldValue(source: Source, record: any, req: any, res: any): string | undefined {
+        switch (source.type) {
+            case "req-header":
+                return this.requestAccessor.getHeaderField(req, source.name!);
+            case "req-object":
+                return this.requestAccessor.getField(req, source.name!);
+            case "res-header":
+                return this.responseAccessor.getHeaderField(res, source.name!);
+            case "res-object":
+                return this.responseAccessor.getField(res, source.name!);
+            default:
+                return this.getFieldValue(source, record);
+        }
+    }
+
+    // if source is request, then assign to context. If not, then ignore.
+    getContextFieldValue(source: Source, req: any) {
+        switch (source.type) {
+            case "req-header":
+                return this.requestAccessor.getHeaderField(req, source.name!);
+            case "req-object":
+                return this.requestAccessor.getField(req, source.name!);
+            case "uuid":
+                return uuid();
+        }
+    }
+
+    // iterate through sources until one source returns a value 
+    getValueFromSources(record: any, field: ConfigField, origin: origin, req?: any, res?: any) {
+
+        if (origin == "req-log" && (!req || !res)) {
+            throw new Error("Please pass req and res as argument to get value for req-log field.");
+        }
+
+        if (origin == "context" && (!req)) {
+            throw new Error("Please pass req as argument to get value for context field.");
+        }
+
+        field.source = field.source as Source[];
+
+        let sourceIndex = 0;
+        while (!record[field.name]) {
+            sourceIndex = SourceUtils.getInstance().getNextValidSourceIndex(field.source, sourceIndex);
+
+            if (sourceIndex == -1) {
+                return;
+            }
+
+            let source = field.source[sourceIndex];
+
+            record[field.name] = origin == "msg-log" ? this.getFieldValue(source, record) :
+                origin == "req-log" ? this.getReqFieldValue(source, record, req, res) :
+                    this.getContextFieldValue(source, req);
+
+            ++sourceIndex;
+        }
+        return record[field.name];
+    }
+
     // returns -1 when all sources were iterated
-    static getNextValidSourceIndex(sources: Source[], startIndex: number): number {
+    private getNextValidSourceIndex(sources: Source[], startIndex: number): number {
         const framework = Config.getInstance().getFramework();
         var i: number = startIndex;
 

--- a/v2/cf-nodejs-logging-support/src/lib/logger/source-utils.ts
+++ b/v2/cf-nodejs-logging-support/src/lib/logger/source-utils.ts
@@ -1,0 +1,20 @@
+import Config from "../config/config";
+import { Source } from "../config/interfaces";
+
+export class SourceUtils {
+    // returns -1 when all sources were iterated
+    static getNextValidSourceIndex(sources: Source[], startIndex?: number): number {
+        const framework = Config.getInstance().getFramework();
+        var i: number = startIndex ? startIndex : 0;
+
+        for (i; i < sources.length; i++) {
+            if (!sources[i].framework) {
+                return i;
+            }
+            if (sources[i].framework == framework) {
+                return i;
+            }
+        }
+        return -1;
+    }
+}

--- a/v2/cf-nodejs-logging-support/src/lib/middleware/interfaces.ts
+++ b/v2/cf-nodejs-logging-support/src/lib/middleware/interfaces.ts
@@ -1,7 +1,7 @@
 export interface IFrameworkService {
-    getReqHeaderField(req: any, fieldName: string): any;
+    getReqHeaderField(req: any, fieldName: string): string;
     getReqField(req: any, fieldName: string): any;
-    getResHeaderField(req: any, fieldName: string): any;
+    getResHeaderField(req: any, fieldName: string): string;
     getResField(req: any, fieldName: string): any;
     finishLog(record: any): any;
 }

--- a/v2/cf-nodejs-logging-support/src/lib/middleware/middleware.ts
+++ b/v2/cf-nodejs-logging-support/src/lib/middleware/middleware.ts
@@ -9,13 +9,13 @@ export default class Middleware {
         let logSent = false;
 
         const networkLogger = RootLogger.getInstance().createLogger();
-        networkLogger.initContext(req);
+        const context = networkLogger.initContext(req);
         req.logger = networkLogger;
 
         const finishLog = () => {
 
             if (!logSent) {
-                const record = RecordFactory.buildReqRecord(req, res);
+                const record = RecordFactory.buildReqRecord(req, res, context);
                 const level = LevelUtils.getLevel(record.level);
                 const loggingLevelThreshold = LevelUtils.getLevel(req.logger.getLoggingLevel());
                 if (LevelUtils.isLevelEnabled(loggingLevelThreshold, level)) {

--- a/v2/cf-nodejs-logging-support/src/lib/middleware/middleware.ts
+++ b/v2/cf-nodejs-logging-support/src/lib/middleware/middleware.ts
@@ -15,7 +15,7 @@ export default class Middleware {
         const finishLog = () => {
 
             if (!logSent) {
-                const record = RecordFactory.buildReqRecord(req, res, context);
+                const record = RecordFactory.getInstance().buildReqRecord(req, res, context);
                 const level = LevelUtils.getLevel(record.level);
                 const loggingLevelThreshold = LevelUtils.getLevel(req.logger.getLoggingLevel());
                 if (LevelUtils.isLevelEnabled(loggingLevelThreshold, level)) {

--- a/v2/cf-nodejs-logging-support/src/lib/middleware/request-accessor.ts
+++ b/v2/cf-nodejs-logging-support/src/lib/middleware/request-accessor.ts
@@ -23,7 +23,7 @@ export default class RequestAccessor {
     };
 
     public getHeaderField(req: any, fieldName: string): string {
-        return this.frameworkService.getReqHeaderField(req, fieldName);;
+        return this.frameworkService.getReqHeaderField(req, fieldName);
     };
 
     public getField(req: any, fieldName: string): any {

--- a/v2/cf-nodejs-logging-support/src/lib/middleware/request-accessor.ts
+++ b/v2/cf-nodejs-logging-support/src/lib/middleware/request-accessor.ts
@@ -1,6 +1,5 @@
 import { IFrameworkService } from "./interfaces";
 import { assignFrameworkService } from "./utils";
-const { v4: uuid } = require('uuid');
 
 export default class RequestAccessor {
     private static instance: RequestAccessor;
@@ -25,9 +24,6 @@ export default class RequestAccessor {
 
     public getHeaderField(req: any, fieldName: string): any {
         let result = this.frameworkService.getReqHeaderField(req, fieldName);
-        if (!result && fieldName == "x-correlationid") {
-            result = uuid();
-        }
         return result;
     };
 

--- a/v2/cf-nodejs-logging-support/src/lib/middleware/request-accessor.ts
+++ b/v2/cf-nodejs-logging-support/src/lib/middleware/request-accessor.ts
@@ -22,9 +22,8 @@ export default class RequestAccessor {
 
     };
 
-    public getHeaderField(req: any, fieldName: string): any {
-        let result = this.frameworkService.getReqHeaderField(req, fieldName);
-        return result;
+    public getHeaderField(req: any, fieldName: string): string {
+        return this.frameworkService.getReqHeaderField(req, fieldName);;
     };
 
     public getField(req: any, fieldName: string): any {

--- a/v2/cf-nodejs-logging-support/src/lib/middleware/request-accessor.ts
+++ b/v2/cf-nodejs-logging-support/src/lib/middleware/request-accessor.ts
@@ -1,10 +1,6 @@
-import ExpressService from "./framework-services/express";
-import Config from "../config/config";
-import RestifyService from "./framework-services/restify";
-import HttpService from "./framework-services/plainhttp";
-import ConnectService from "./framework-services/connect";
 import { IFrameworkService } from "./interfaces";
 import { assignFrameworkService } from "./utils";
+const { v4: uuid } = require('uuid');
 
 export default class RequestAccessor {
     private static instance: RequestAccessor;
@@ -28,7 +24,11 @@ export default class RequestAccessor {
     };
 
     public getHeaderField(req: any, fieldName: string): any {
-        return this.frameworkService.getReqHeaderField(req, fieldName);
+        let result = this.frameworkService.getReqHeaderField(req, fieldName);
+        if (!result && fieldName == "x-correlationid") {
+            result = uuid();
+        }
+        return result;
     };
 
     public getField(req: any, fieldName: string): any {

--- a/v2/cf-nodejs-logging-support/src/lib/middleware/response-accessor.ts
+++ b/v2/cf-nodejs-logging-support/src/lib/middleware/response-accessor.ts
@@ -16,7 +16,7 @@ export default class ResponseAccessor {
         return ResponseAccessor.instance;
     }
 
-    public getHeaderField(res: any, fieldName: string): any {
+    public getHeaderField(res: any, fieldName: string): string {
         return this.frameworkService.getResHeaderField(res, fieldName);
     };
 

--- a/v2/cf-nodejs-logging-support/src/test/unit-test/config.test.js
+++ b/v2/cf-nodejs-logging-support/src/test/unit-test/config.test.js
@@ -43,7 +43,11 @@ describe('Test Config class', function () {
                         },
                         "output": [
                             "msg-log"
-                        ]
+                        ],
+                        "_meta": {
+                            "isEnabled": true,
+                            "isRedacted": false
+                        }
                     }, {
                         "name": "request",
                         "mandatory": true,
@@ -53,7 +57,11 @@ describe('Test Config class', function () {
                         },
                         "output": [
                             "req-log"
-                        ]
+                        ],
+                        "_meta": {
+                            "isEnabled": true,
+                            "isRedacted": false
+                        }
                     }
                 ];
                 expect(result).to.be.eql(expectation);
@@ -83,7 +91,11 @@ describe('Test Config class', function () {
                 },
                 "output": [
                     "msg-log"
-                ]
+                ],
+                "_meta": {
+                    "isEnabled": true,
+                    "isRedacted": false
+                }
             }];
             expect(result.length).to.be.eql(1);
             expect(result).to.be.eql(expectation);
@@ -148,7 +160,11 @@ describe('Test Config class', function () {
                     },
                     "output": [
                         "msg-log"
-                    ]
+                    ],
+                    "_meta": {
+                        "isEnabled": true,
+                        "isRedacted": false
+                    }
                 },
                 {
                     "name": "disabled_field",
@@ -160,7 +176,11 @@ describe('Test Config class', function () {
                     "output": [
                         "msg-log"
                     ],
-                    "disable": true
+                    "disable": true,
+                    "_meta": {
+                        "isEnabled": false,
+                        "isRedacted": false
+                    }
                 },
                 {
                     "name": "new_field",
@@ -171,7 +191,11 @@ describe('Test Config class', function () {
                     },
                     "output": [
                         "msg-log"
-                    ]
+                    ],
+                    "_meta": {
+                        "isEnabled": true,
+                        "isRedacted": false
+                    }
                 }
             ];
             expect(newFieldsData.length).to.be.gt(0);
@@ -194,6 +218,10 @@ describe('Test Config class', function () {
                 "output": [
                     "msg-log"
                 ],
+                "_meta": {
+                    "isEnabled": false,
+                    "isRedacted": false
+                },
                 "disable": true
             }];
             expect(result).to.be.eql(expectation);


### PR DESCRIPTION
- Log stacktraces.
- Log custom fields in application- or cloud-logging format.
- Handle config fields with source as array: 
    - User can declare different sources elements, library will iterate the sources until one returns a value. 
    - A source element can also be declared for a specific framework service.