### PR TITLE
Avoid publishing dev folders like docs & tools via package.json files property

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,7 +1,0 @@
-test
-sample
-.jshintrc
-coverage
-.vscode/*
-.travis.yml
-.nyc_output

--- a/package.json
+++ b/package.json
@@ -44,7 +44,6 @@
   "files": [
     "/.reuse/",
     "/core/",
-    "/docs/",
     "/logger/",
     "/trace/",
     "/winston/",

--- a/package.json
+++ b/package.json
@@ -40,5 +40,15 @@
   "scripts": {
     "test": "mocha -- --timeout 10000",
     "coverage": "nyc --reporter=lcov --reporter=text-summary npm run test"
-  }
+  },
+  "files": [
+    "/.reuse/",
+    "/core/",
+    "/docs/",
+    "/logger/",
+    "/trace/",
+    "/winston/",
+    "config.js",
+    "index.js"
+  ]
 }


### PR DESCRIPTION
Solves #137 by specifying only the necessary files & folders in the [files](https://docs.npmjs.com/cli/v8/configuring-npm/package-json#files) property of the `package.json`.