### PR TITLE
Avoid publishing dev folders like docs & tools

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,4 +1,6 @@
+docs
 test
+tools
 sample
 .jshintrc
 coverage


### PR DESCRIPTION
Solves #137 by extending the `.npmignore` file.