### PR TITLE
Initialise reqContext in middleware

### DIFF
--- a/v2/cf-nodejs-logging-support/src/lib/logger/logger.ts
+++ b/v2/cf-nodejs-logging-support/src/lib/logger/logger.ts
@@ -14,10 +14,13 @@ export default class Logger {
     private recordWriter: RecordWriter;
     protected loggingLevelThreshold: Level = Level.INHERIT
 
-    constructor(parent?: Logger) {
+    constructor(parent?: Logger, reqContext?: ReqContext) {
         if (parent) {
             this.parent = parent;
             this.registeredCustomFields = parent.registeredCustomFields;
+        }
+        if (reqContext) {
+            this.context = reqContext;
         }
         this.recordFactory = RecordFactory.getInstance();
         this.recordWriter = RecordWriter.getInstance();
@@ -149,11 +152,6 @@ export default class Logger {
 
     setTenantSubdomain(value: string) {
         this.context?.setProp("tenant_subdomain", value);
-    }
-
-    initContext(_req: any) {
-        this.context = new ReqContext(_req);
-        return this.context;
     }
 
     private extractCustomFieldsFromLogger(logger: Logger): any {

--- a/v2/cf-nodejs-logging-support/src/lib/middleware/middleware.ts
+++ b/v2/cf-nodejs-logging-support/src/lib/middleware/middleware.ts
@@ -4,15 +4,19 @@ import RootLogger from "../logger/root-logger";
 import { JWTService } from "../config/jwt-service";
 import RequestAccessor from "./request-Accessor";
 import RecordWriter from "../logger/record-writer";
+import ReqContext from "../logger/context";
+import Logger from "../logger/logger";
 
 export default class Middleware {
 
     static logNetwork(req: any, res: any, next?: any) {
         let logSent = false;
 
-        let networkLogger = RootLogger.getInstance().createLogger();
+        const context = new ReqContext(req);
+        const parent = RootLogger.getInstance();
+        // initialize Logger with parent to set registered fields
+        let networkLogger = new Logger(parent, context);
         let jwtService = JWTService.getInstance();
-        const context = networkLogger.initContext(req);
 
         var dynLogLevelHeader = jwtService.getDynLogLevelHeaderName();
         var token = RequestAccessor.getInstance().getHeaderField(req, dynLogLevelHeader);


### PR DESCRIPTION
Problem: Logger.initContext is public and should not be exported.
Solution: init context in middleware and save in Logger instance through constructor.