### PR TITLE
Add check for public key parameter type

### DIFF
--- a/core/log-core.js
+++ b/core/log-core.js
@@ -908,7 +908,7 @@ var bindDynLogLevel = function (token, logger) {
 
 // Verifies the given JWT and returns its payload.
 var verifyAndDecodeJWT = function (token, key) {
-    if (key == null || !token) {
+    if (key == null || typeof key !== "string" || !token) {
         return null; // no public key or jwt provided
     }
 

--- a/core/log-core.js
+++ b/core/log-core.js
@@ -908,7 +908,7 @@ var bindDynLogLevel = function (token, logger) {
 
 // Verifies the given JWT and returns its payload.
 var verifyAndDecodeJWT = function (token, key) {
-    if (key == null || typeof key !== "string" || !token) {
+    if (!token || !key || typeof key !== "string") {
         return null; // no public key or jwt provided
     }
 


### PR DESCRIPTION
Check that the provided public key parameter is actually a string before running the `.match(...)` in subsequent conditional statement. Further details can be found the related issue #169.