### PR TITLE
Fix custom fields processing

### DIFF
--- a/src/lib/logger/logger.ts
+++ b/src/lib/logger/logger.ts
@@ -26,7 +26,7 @@ export default class Logger {
         this.recordWriter = RecordWriter.getInstance();
     }
 
-    createLogger(customFields?: Map<string, any>): Logger {
+    createLogger(customFields?: Map<string, any> | Object): Logger {
 
         let logger = new Logger(this);
         // assign custom fields, if provided
@@ -178,8 +178,7 @@ export default class Logger {
         if (logger.parent && logger.parent !== this) {
             let parentFields = this.getCustomFieldsFromLogger(logger.parent);
             return new Map([...parentFields, ...logger.customFields]);
-        } else {
-            return logger.customFields;
         }
+        return logger.customFields;
     }
 }

--- a/src/lib/logger/recordFactory.ts
+++ b/src/lib/logger/recordFactory.ts
@@ -93,13 +93,13 @@ export default class RecordFactory {
 
         // assign custom fields
         const loggerCustomFields = req.logger.getCustomFieldsFromLogger(req.logger);
-        this.addCustomFields(record, req.logger.registeredCustomFields, loggerCustomFields, new Map<string, any>());
+        this.addCustomFields(record, req.logger.registeredCustomFields, loggerCustomFields);
 
         return record;
     }
 
     private addCustomFields(record: Record, registeredCustomFields: Array<string>, loggerCustomFields: Map<string, any>, 
-        customFieldsFromArgs: Map<string, any>) {
+        customFieldsFromArgs: Map<string, any> = new Map()) {
         const providedFields = new Map<string, any>([...loggerCustomFields, ...customFieldsFromArgs]);
         const customFieldsFormat = this.config.getConfig().customFieldsFormat!;
 

--- a/src/lib/logger/recordFactory.ts
+++ b/src/lib/logger/recordFactory.ts
@@ -63,7 +63,7 @@ export default class RecordFactory {
         record.metadata.message = util.format.apply(util, args);
 
         // assign dynamic fields
-        this.addDynamicFields(record, Output.MsgLog, new Date());
+        this.addDynamicFields(record, Output.MsgLog);
 
         // assign values from request context if present
         if (context) {


### PR DESCRIPTION
A mixed/inconsistent usage of Object and Map types caused missing custom fields and even crashes (reported in #181).
- Use Map type for handling custom fields internally and keep support for custom fields parsed as object.
- Add/update test cases to ensure that custom field processing works with Maps and Objects.
- Remove incorrect method call.

