### PR TITLE
Fix context inheritance and optionally add context to global loggers

### DIFF
--- a/docs/Gemfile.lock
+++ b/docs/Gemfile.lock
@@ -210,12 +210,14 @@ GEM
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
     mercenary (0.3.6)
+    mini_portile2 (2.8.2)
     minima (2.5.1)
       jekyll (>= 3.5, < 5.0)
       jekyll-feed (~> 0.9)
       jekyll-seo-tag (~> 2.1)
     minitest (5.18.0)
-    nokogiri (1.15.2-arm64-darwin)
+    nokogiri (1.15.2)
+      mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
     nokogiri (1.15.2-x86_64-darwin)
       racc (~> 1.4)
@@ -261,6 +263,7 @@ GEM
     zeitwerk (2.6.8)
 
 PLATFORMS
+  ruby
   universal-darwin-20
   x86_64-darwin-21
   x86_64-linux

--- a/docs/general-usage/03-logging-contexts.md
+++ b/docs/general-usage/03-logging-contexts.md
@@ -19,21 +19,22 @@ permalink: /general-usage/logging-contexts
 </details>
 
 ## Concept
-Logging contexts are an essential concept of this library. 
-Consider a context as a set of information related to the environment, processes, thread and/or function call code gets executed in.
-More specifically a logging context stores metadata which get written along with the raw log messages.
+Logging contexts are an essential concept of this library to extend the metadata attached to each log message.
+It offers correlation of log messages by enriching them with shared properties, such as the `correlation_id` of a request, class names or even details on the method being executed.
+While all log messages contain various information on the runtime environment or various request/response details for request logs, logging contexts are more flexible and allow extension at runtime.
 
-There are three important rules that apply to this concept:
-- There is exactly one *global* root context.
-- All other contexts inherit from their parent context.
-- Sub-contexts can extend and override the provided metadata.
+You can create [Child Loggers](/cf-nodejs-logging-support/advanced-usage/child-loggers) to inherit or create new logging contexts.
 
-Besides the *global* context each request handled by your application has its own *request* context, directly inheriting from the *global* context.
+There are three *kinds* of contexts:
 
-You can create [Child Loggers](/cf-nodejs-logging-support/general-usage/logging-contexts) to inherit and extend the *global* context or *request* contexts.
+* global context
+* request context
+* custom context
 
-## Global context
-The *global* context has no correlation to specific requests but provides metadata about the application itself and its environment. Use the imported `log` object to log messages in *global* context:
+## Global Context
+
+As messages written in *global* context are considered uncorrelated, it is always empty and immutable.
+Use the imported `log` object to log messages in *global* context:
 
 ```js
 var log = require("cf-nodejs-logging-support");
@@ -41,9 +42,20 @@ var log = require("cf-nodejs-logging-support");
 log.info("Message logged in global context"); 
 ```
 
+Adding context properties is not possible, which is indicated by the return value of the setter methods:
+
+```js
+var log = require("cf-nodejs-logging-support");
+...
+var result = log.setContextProperty("my-property", "my-value")
+// result: false
+```
+
 ## Request context
-The library adds context bound functions to request objects in case it has been [attached as middleware](/cf-nodejs-logging-support/general-usage/request-logs#attaching-to-server-frameworks). 
+
+The library adds context bound functions to request objects in case it has been [attached as middleware](/cf-nodejs-logging-support/general-usage/request-logs#attaching-to-server-frameworks).
 Use the provided `req.logger` object to log messages in *request* contexts:
+
 ```js
 app.get('/', function (req, res) {
     var reqLogger = req.logger; // reqLogger logs in request context
@@ -52,8 +64,15 @@ app.get('/', function (req, res) {
 });
 ```
 
-In addition to the *global* context *request* contexts provide following request related fields to logs:
-- `correlation_id`
-- `request_id`
-- `tenant_id`
-- `tenant_subdomain`
+By default, *request* contexts provide following additional request related fields to logs:
+
+* `correlation_id`
+* `request_id`
+* `tenant_id`
+* `tenant_subdomain`
+
+## Custom context
+
+Child loggers can also be equipped with a newly created context, including an auto-generated `correlation_id`.
+This can be useful when log messages should be correlated without being in context of an HTTP request.
+Switch over to the [Child loggers with custom context](/cf-nodejs-logging-support/advanced-usage/child-loggers#child-loggers-with-custom-context) section to learn more about this topic.

--- a/src/lib/logger/context.ts
+++ b/src/lib/logger/context.ts
@@ -2,7 +2,7 @@ import Config from '../config/config';
 import { Output } from '../config/interfaces';
 import SourceUtils from './sourceUtils';
 
-export default class RequestContext {
+export default class Context {
     private properties: any = {};
     private config: Config;
     private sourceUtils: SourceUtils;

--- a/src/lib/logger/logger.ts
+++ b/src/lib/logger/logger.ts
@@ -3,18 +3,18 @@ import { isValidObject } from '../middleware/utils';
 import { Level } from './level';
 import RecordFactory from './recordFactory';
 import RecordWriter from './recordWriter';
-import RequestContext from './requestContext';
+import Context from './context';
 
 export default class Logger {
     private parent?: Logger = undefined
-    private context?: RequestContext;
+    private context?: Context;
     private registeredCustomFields: Array<string> = [];
     private customFields: Map<string, any> = new Map<string, any>()
     private recordFactory: RecordFactory;
     private recordWriter: RecordWriter;
     protected loggingLevelThreshold: Level = Level.Inherit
 
-    constructor(parent?: Logger, context?: RequestContext) {
+    constructor(parent?: Logger, context?: Context) {
         if (parent) {
             this.parent = parent;
             this.registeredCustomFields = parent.registeredCustomFields;
@@ -36,7 +36,7 @@ export default class Logger {
     }
 
     createContext() {
-        this.context = new RequestContext();
+        this.context = new Context();
     }
 
     setLoggingLevel(level: string | Level) {

--- a/src/lib/logger/logger.ts
+++ b/src/lib/logger/logger.ts
@@ -14,21 +14,20 @@ export default class Logger {
     private recordWriter: RecordWriter;
     protected loggingLevelThreshold: Level = Level.Inherit
 
-    constructor(parent?: Logger, reqContext?: RequestContext) {
+    constructor(parent?: Logger, context?: RequestContext) {
         if (parent) {
             this.parent = parent;
             this.registeredCustomFields = parent.registeredCustomFields;
         }
-        if (reqContext) {
-            this.context = reqContext;
+        if (context) {
+            this.context = context;
         }
         this.recordFactory = RecordFactory.getInstance();
         this.recordWriter = RecordWriter.getInstance();
     }
 
     createLogger(customFields?: Map<string, any> | Object): Logger {
-
-        let logger = new Logger(this);
+        let logger = new Logger(this, this.context);
         // assign custom fields, if provided
         if (customFields) {
             logger.setCustomFields(customFields);
@@ -66,7 +65,7 @@ export default class Logger {
         if (!this.isLoggingLevel(level)) return;
         const loggerCustomFields = this.getCustomFieldsFromLogger(this);
 
-        let levelName : string;
+        let levelName: string;
         if (typeof level === 'string') {
             levelName = level;
         } else {

--- a/src/lib/logger/logger.ts
+++ b/src/lib/logger/logger.ts
@@ -146,32 +146,36 @@ export default class Logger {
         return this.context?.getProperty(name);
     }
 
-    setContextProperty(name: string, value: string) {
-        this.context?.setProperty(name, value);
+    setContextProperty(name: string, value: string) : boolean {
+        if (this.context) {
+            this.context.setProperty(name, value);
+            return true
+        }
+        return false
     }
 
     getCorrelationId(): string | undefined {
         return this.getContextProperty("correlation_id");
     }
 
-    setCorrelationId(value: string) {
-        this.setContextProperty("correlation_id", value);
+    setCorrelationId(value: string) : boolean {
+        return this.setContextProperty("correlation_id", value);
     }
 
     getTenantId(): string | undefined {
         return this.getContextProperty("tenant_id");
     }
 
-    setTenantId(value: string) {
-        this.setContextProperty("tenant_id", value);
+    setTenantId(value: string) : boolean {
+        return this.setContextProperty("tenant_id", value);
     }
 
     getTenantSubdomain(): string | undefined {
         return this.getContextProperty("tenant_subdomain");
     }
 
-    setTenantSubdomain(value: string) {
-        this.setContextProperty("tenant_subdomain", value);
+    setTenantSubdomain(value: string) : boolean {
+        return this.setContextProperty("tenant_subdomain", value);
     }
 
     private getCustomFieldsFromLogger(logger: Logger): Map<string, any> {

--- a/src/lib/logger/logger.ts
+++ b/src/lib/logger/logger.ts
@@ -35,6 +35,10 @@ export default class Logger {
         return logger;
     }
 
+    createContext() {
+        this.context = new RequestContext();
+    }
+
     setLoggingLevel(level: string | Level) {
         if (typeof level === 'string') {
             this.loggingLevelThreshold = LevelUtils.getLevel(level)

--- a/src/lib/logger/logger.ts
+++ b/src/lib/logger/logger.ts
@@ -26,17 +26,14 @@ export default class Logger {
         this.recordWriter = RecordWriter.getInstance();
     }
 
-    createLogger(customFields?: Map<string, any> | Object): Logger {
-        let logger = new Logger(this, this.context);
+    createLogger(customFields?: Map<string, any> | Object, createNewContext?: boolean): Logger {
+        let context = createNewContext == true ? new Context() : this.context
+        let logger = new Logger(this, context);
         // assign custom fields, if provided
         if (customFields) {
             logger.setCustomFields(customFields);
         }
         return logger;
-    }
-
-    createContext() {
-        this.context = new Context();
     }
 
     setLoggingLevel(level: string | Level) {

--- a/src/lib/logger/recordFactory.ts
+++ b/src/lib/logger/recordFactory.ts
@@ -7,7 +7,7 @@ import StacktraceUtils from '../helper/stacktraceUtils';
 import { isValidObject } from '../middleware/utils';
 import Cache from './cache';
 import Record from './record';
-import RequestContext from './requestContext';
+import Context from './context';
 import SourceUtils from './sourceUtils';
 
 export default class RecordFactory {
@@ -34,7 +34,7 @@ export default class RecordFactory {
     }
 
     // init a new record and assign fields with output "msg-log"
-    buildMsgRecord(registeredCustomFields: Array<string>, loggerCustomFields: Map<string, any>, levelName: string, args: Array<any>, context?: RequestContext): Record {
+    buildMsgRecord(registeredCustomFields: Array<string>, loggerCustomFields: Map<string, any>, levelName: string, args: Array<any>, context?: Context): Record {
         const lastArg = args[args.length - 1];
         let customFieldsFromArgs = new Map<string, any>();
         let record = new Record(levelName)
@@ -77,7 +77,7 @@ export default class RecordFactory {
     }
 
     // init a new record and assign fields with output "req-log"
-    buildReqRecord(levelName: string, req: any, res: any, context: RequestContext): Record {
+    buildReqRecord(levelName: string, req: any, res: any, context: Context): Record {
         let record = new Record(levelName)
 
         // assign static fields from cache
@@ -149,7 +149,7 @@ export default class RecordFactory {
     }
 
     // read and copy values from context
-    private addContext(record: Record, context: RequestContext) {
+    private addContext(record: Record, context: Context) {
         const contextFields = context.getProperties();
         for (let key in contextFields) {
             if (contextFields[key] != null) {

--- a/src/lib/logger/requestContext.ts
+++ b/src/lib/logger/requestContext.ts
@@ -7,7 +7,7 @@ export default class RequestContext {
     private config: Config;
     private sourceUtils: SourceUtils;
 
-    constructor(req: any) {
+    constructor(req?: any) {
         this.config = Config.getInstance();
         this.sourceUtils = SourceUtils.getInstance();
         this.assignProperties(req);

--- a/src/lib/middleware/middleware.ts
+++ b/src/lib/middleware/middleware.ts
@@ -3,7 +3,7 @@ import LevelUtils from '../helper/levelUtils';
 import Logger from '../logger/logger';
 import RecordFactory from '../logger/recordFactory';
 import RecordWriter from '../logger/recordWriter';
-import RequestContext from '../logger/requestContext';
+import Context from '../logger/context';
 import RootLogger from '../logger/rootLogger';
 import RequestAccessor from './requestAccessor';
 import Config from '../config/config';
@@ -13,7 +13,7 @@ export default class Middleware {
     static logNetwork(req: any, res: any, next?: any) {
         let logSent = false;
 
-        const context = new RequestContext(req);
+        const context = new Context(req);
         const parentLogger = RootLogger.getInstance();
         const reqReceivedAt = Date.now();
 

--- a/src/test/acceptance-test/child-logger.test.js
+++ b/src/test/acceptance-test/child-logger.test.js
@@ -116,6 +116,60 @@ describe('Test child logger', function () {
         });
     });
 
+    describe('Test context features', function () {
+
+        describe('Create child logger without context', function () {
+
+            beforeEach(function () {
+                childLogger = log.createLogger();
+            });
+
+            it('cannot set context properties', function () {
+                expect(childLogger.setContextProperty('some-field', 'some-value')).to.be.false;
+            });
+    
+            it('does not log a custom context property', function () {
+                childLogger.setContextProperty('some-field', 'some-value');
+                childLogger.warn('test-message');
+                expect(lastOutput).to.not.include.key('some-field');
+            });
+    
+            it('does not log the correlation_id', function () {
+                childLogger.warn("test-message");
+                expect(lastOutput).to.not.include.key('correlation_id');
+            });
+        });
+
+        describe('Create child logger with new context', function () {
+
+            beforeEach(function () {
+                childLogger = log.createLogger(null, true);
+            });
+
+            it('sets context properties', function () {
+                expect(childLogger.setContextProperty('some-field', 'some-value')).to.be.true;
+            });
+    
+            it('logs a custom context property', function () {
+                childLogger.setContextProperty('some-field', 'some-value');
+                childLogger.warn('test-message');
+                expect(lastOutput).to.include.property('some-field', 'some-value');
+            });
+
+            it('inherits the context', function () {
+                childLogger.setContextProperty('some-field', 'some-value');
+                childLogger.createLogger().warn('test-message');
+                expect(lastOutput).to.include.property('some-field', 'some-value');
+            });
+    
+            it('generates a correlation_id', function () {
+                childLogger.warn("test-message");
+                expect(lastOutput).to.include.key('correlation_id');
+                expect(lastOutput.correlation_id).to.match(/[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[0-9a-f]{4}-[0-9a-f]{12}/);
+            });
+        });
+    });
+
     describe('Set logging level threshold per child logger', function () {
 
         describe('Child logger sets treshold', function () {

--- a/src/test/acceptance-test/global-context.test.js
+++ b/src/test/acceptance-test/global-context.test.js
@@ -183,6 +183,26 @@ describe('Test logging in global context', function () {
 
     });
 
+    describe('Test disabled context', function () {
+
+        it('cannot set context properties', function () {
+            expect(log.setContextProperty("some-field", "some-value")).to.be.false;
+        });
+
+        it('cannot set the correlation_id', function () {
+            expect(log.setCorrelationId("f79ed23f-cff6-4599-8668-12838c898b70")).to.be.false;
+        });
+
+        it('cannot set the tenant_id', function () {
+            expect(log.setTenantId("some-value")).to.be.false;
+        });
+
+        it('cannot set the correlation_id', function () {
+            expect(log.setTenantSubdomain("some-value")).to.be.false;
+        });
+
+    });
+
     after(function () {
         log.setLoggingLevel("info");
     })


### PR DESCRIPTION
Changes
* Fix context inheritance
   * Child loggers inherit context fields (e.g., correlation_id) from their parent logger, if present.
* Add context to global child loggers
   * Child loggers derived from the global logger _optionally_ support context features now. This includes
     * support for `setContextProperty()`, `setCorrelationId()`, `setTenantId()`, `setTenantSubdomain()` and the respective _get_ methods.
     * auto-generated correlation_id (default configuration)
     * context inheritance
   * A new child logger can be equipped with a **new** context by specifying `true` for the `createNewContext` parameter:
 
     ```js
     const logger = log.createLogger(null, true)
     ```
* Add a boolean return value for `setContextProperty()`, `setCorrelationId()`, `setTenantId()` and `setTenantSubdomain()` to indicate if the _set_ operation was successful. If a logger does not have a context, the fields cannot be set and the methods return `false`. 
* Add test cases for context inheritance
* Add/update documentation on contexts and child loggers

Fixes #185 