### PR TITLE
Add logger to exported types

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,4 @@
 import RootLogger from "./lib/logger/rootLogger";
-
 const rootLogger = RootLogger.getInstance();
 
 module.exports = rootLogger; // assign default export
@@ -8,3 +7,4 @@ exports = module.exports; // re-assign exports
 export default rootLogger;
 export * from "./lib/config/interfaces";
 export * from "./lib/logger/level";
+export * from "./lib/logger/logger";

--- a/src/lib/logger/logger.ts
+++ b/src/lib/logger/logger.ts
@@ -5,7 +5,7 @@ import RecordFactory from './recordFactory';
 import RecordWriter from './recordWriter';
 import Context from './context';
 
-export default class Logger {
+export class Logger {
     private parent?: Logger = undefined
     private context?: Context;
     private registeredCustomFields: Array<string> = [];

--- a/src/lib/logger/recordWriter.ts
+++ b/src/lib/logger/recordWriter.ts
@@ -2,7 +2,6 @@ import os from 'os';
 
 import Record from './record';
 
-
 export default class RecordWriter {
 
     private static instance: RecordWriter;

--- a/src/lib/logger/rootLogger.ts
+++ b/src/lib/logger/rootLogger.ts
@@ -8,7 +8,7 @@ import RequestAccessor from '../middleware/requestAccessor';
 import ResponseAccessor from '../middleware/responseAccessor';
 import createTransport from '../winston/winstonTransport';
 import { Level } from './level';
-import Logger from './logger';
+import { Logger } from './logger';
 import RecordWriter from './recordWriter';
 
 export default class RootLogger extends Logger {

--- a/src/lib/middleware/middleware.ts
+++ b/src/lib/middleware/middleware.ts
@@ -1,6 +1,6 @@
 import JWTService from '../helper/jwtService';
 import LevelUtils from '../helper/levelUtils';
-import Logger from '../logger/logger';
+import { Logger } from '../logger/logger';
 import RecordFactory from '../logger/recordFactory';
 import RecordWriter from '../logger/recordWriter';
 import Context from '../logger/context';

--- a/src/lib/winston/winstonTransport.ts
+++ b/src/lib/winston/winstonTransport.ts
@@ -1,6 +1,6 @@
 import TripleBeam from 'triple-beam';
 import TransportStream from 'winston-transport';
-import Logger from '../logger/logger';
+import { Logger } from '../logger/logger';
 
 class CfNodejsLoggingSupportLogger extends TransportStream {
 


### PR DESCRIPTION
- Exporting `Logger` allows better handling of created Logger instances in TypeScript apps, i.e., when passing it to classes or methods.