### PR TITLE
Promote `triple-beam` to regular dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,6 @@
     "restify": "^11.1.0",
     "rewire": "^6.0.0",
     "supertest": "^6.2.2",
-    "triple-beam": "^1.3.0",
     "typescript": "^5.1.3",
     "typescript-json-schema": "^0.55.0"
   },
@@ -64,6 +63,7 @@
     "ajv": "^8.11.0",
     "json-stringify-safe": "^5.0.1",
     "jsonwebtoken": "^9.0.0",
+    "triple-beam": "^1.3.0",
     "uuid": "^9.0.0",
     "winston-transport": "^4.5.0"
   }


### PR DESCRIPTION
`triple-beam` is imported at runtime in `src/lib/winston/winstonTransport.ts`, but is not declared as a regular dependency, which leads to issues when used with `pnpm`.

Steps to reproduce
- clone repository
- `npm install && npm run build`
- `pnpm install --prod`
- `node build/main/index.js`

Expected behavior: no output.

Observed behavior:

```
node:internal/modules/cjs/loader:1080
  throw err;
  ^

Error: Cannot find module 'triple-beam'
Require stack:
- /home/lima.linux/git/cf-nodejs-logging-support/build/main/lib/winston/winstonTransport.js
- /home/lima.linux/git/cf-nodejs-logging-support/build/main/lib/logger/rootLogger.js
- /home/lima.linux/git/cf-nodejs-logging-support/build/main/index.js
    at Module._resolveFilename (node:internal/modules/cjs/loader:1077:15)
    at Module._load (node:internal/modules/cjs/loader:922:27)
    at Module.require (node:internal/modules/cjs/loader:1143:19)
    at require (node:internal/modules/cjs/helpers:119:18)
    at Object.<anonymous> (/home/lima.linux/git/cf-nodejs-logging-support/build/main/lib/winston/winstonTransport.js:6:39)
    at Module._compile (node:internal/modules/cjs/loader:1256:14)
    at Module._extensions..js (node:internal/modules/cjs/loader:1310:10)
    at Module.load (node:internal/modules/cjs/loader:1119:32)
    at Module._load (node:internal/modules/cjs/loader:960:12)
    at Module.require (node:internal/modules/cjs/loader:1143:19) {
  code: 'MODULE_NOT_FOUND',
  requireStack: [
    '/home/lima.linux/git/cf-nodejs-logging-support/build/main/lib/winston/winstonTransport.js',
    '/home/lima.linux/git/cf-nodejs-logging-support/build/main/lib/logger/rootLogger.js',
    '/home/lima.linux/git/cf-nodejs-logging-support/build/main/index.js'
  ]
}
```


Importing `triple-beam` happens to work when installation happens with `npm` or `yarn`, because of the phantom dependencies those package managers introduce. With package managers which try to avoid phantom dependencies (like `pnpm`), `triple-beam` cannot be imported unless it is explicitly declared as a regular dependency.