### PR TITLE
Fix undefined logger for winston transport

### DIFF
--- a/src/lib/logger/rootLogger.ts
+++ b/src/lib/logger/rootLogger.ts
@@ -68,12 +68,12 @@ export default class RootLogger extends Logger {
         return EnvService.getInstance().getBoundServices()
     }
 
-    createWinstonTransport(options: any) {
+    createWinstonTransport(options?: any) {
         if (!options) {
-            options = {
-                level: 'info',
-                rootLogger: this
-            };
+            options = {};
+        }
+        if (!options.rootLogger) {
+            options.rootLogger = this;
         }
         return createTransport(options);
     }

--- a/src/test/unit-test/winston-transport.test.js
+++ b/src/test/unit-test/winston-transport.test.js
@@ -68,16 +68,19 @@ describe('Test winston-transport.js', function () {
         it('Test default initialization', function () {
             var transport = logger.createWinstonTransport();
             transport.level.should.equal("info");
+            transport.logger.should.equal(logger);
         });
 
         it('Test custom initialization', function () {
             var transport = logger.createWinstonTransport({ level: "error" });
             transport.level.should.equal("error");
+            transport.logger.should.equal(logger);
         });
 
         it('Test incomplete initialization', function () {
             var transport = logger.createWinstonTransport({});
             transport.level.should.equal("info");
+            transport.logger.should.equal(logger);
         });
     });
 });


### PR DESCRIPTION
This change fixes an error caused by an undefined logger attribute after initializing the winston transport.
