### PR TITLE
Optionally retain custom field types

### DIFF
--- a/docs/Gemfile
+++ b/docs/Gemfile
@@ -33,3 +33,5 @@ gem "just-the-docs"
 
 
 gem "webrick", "~> 1.7"
+
+gem "jekyll", "~> 3.9"

--- a/docs/Gemfile.lock
+++ b/docs/Gemfile.lock
@@ -287,6 +287,7 @@ PLATFORMS
 
 DEPENDENCIES
   github-pages (~> 228)
+  jekyll (~> 3.9)
   jekyll-feed (~> 0.12)
   just-the-docs
   tzinfo (~> 1.2)

--- a/docs/configuration/custom-fields-format.md
+++ b/docs/configuration/custom-fields-format.md
@@ -21,8 +21,14 @@ Example:
 
 Supported format values:
 
-* `application-logging`
-* `cloud-logging`
+* `application-logging`: to be used with SAP Application Logging
+* `cloud-logging`: to be used with SAP Cloud Logging
 * `all`: use application-logging and cloud-logging format in parallel.
 * `disabled`: do not log any custom fields.
 * `default`: set default format cloud-logging.
+
+Additionally, the `customFieldsTypeConversion` setting can be set when logging in cloud-logging format:
+
+* `stringify`: convert all custom field values to strings
+* `retain`: keep the original custom field value types
+

--- a/docs/general-usage/04-custom-fields.md
+++ b/docs/general-usage/04-custom-fields.md
@@ -10,24 +10,12 @@ permalink: /general-usage/custom-fields
 
 You can use the custom field feature to add custom fields to your logs.
 
-## Register custom fields for SAP Application Logging
 
-In case you want to use this library with SAP Application Logging Service you need to register your custom fields.
-Please make sure to call the registration exactly once globally before logging any custom fields.
-Registered fields will be indexed based on the order given by the provided field array.
+## Format and type transformation for SAP logging services
 
-```js
-log.registerCustomFields(["field"]);
-info("Test data", {"field" :"value"}); 
-// ... "msg":"Test data" 
-// ... "#cf": {"string": [{"k":"field","v":"value","i":"0"}]}...
-```
+The library will automatically detect which logging service is bound to your app and will set the custom field format accordingly.
 
-## General use
-
-As of version 6.5.0 this library will automatically detect which logging service your app is bound to and will set the logging format accordingly.
-
-For local testing purposes you can still enforce a specific format like this:
+For local testing purposes you can enforce a specific format like this:
 
 ```js
 log.setCustomFieldsFormat("application-logging");
@@ -35,6 +23,38 @@ log.setCustomFieldsFormat("application-logging");
 ```
 
 Alternatively, you can force the logging format by setting a configuration file as explained in [Custom Fields Format](/cf-nodejs-logging-support/configuration/custom-fields-format).
+
+### SAP Application Logging
+
+In case you want to use this library with SAP Application Logging Service you need to register your custom fields.
+Please make sure to call the registration exactly once globally before logging any custom fields.
+Registered fields will be indexed based on the order given by the provided field array.
+
+Custom fields are converted and printed as string values independent of their original type.
+
+```js
+log.registerCustomFields(["field"]);
+info("Test data", {"field": 42}); 
+// ... "msg":"Test data" 
+// ... "#cf": {"string": [{"k":"field","v":"42","i":"0"}]}...
+```
+
+### SAP Cloud Logging
+
+When using the library with SAP Cloud Logging custom fields get added as top-level fields.
+Registering custom fields is not required in this case.
+
+By default all custom field values get stringified, which can help to prevent field type mismatches when indexing to SAP Cloud Logging.
+However, if you want to retain the original type of your custom fields you can change the type conversion configuration accordingly:
+
+```js
+log.setCustomFieldsTypeConversion(CustomFieldsTypeConversion.Retain)
+info("Test data", {"field": 42}); 
+// ... "msg":"Test data" 
+// ... "field": 42
+```
+
+## Adding custom fields
 
 In addition to logging messages as described in [Message Logs](/cf-nodejs-logging-support/general-usage/message-logs) you can attach custom fields as an object of key-value pairs as last parameter:
 

--- a/docs/general-usage/04-custom-fields.md
+++ b/docs/general-usage/04-custom-fields.md
@@ -41,11 +41,11 @@ info("Test data", {"field": 42});
 
 ### SAP Cloud Logging
 
-When using the library with SAP Cloud Logging custom fields get added as top-level fields.
+When using the library with SAP Cloud Logging, custom fields get added as top-level fields.
 Registering custom fields is not required in this case.
 
 By default all custom field values get stringified, which can help to prevent field type mismatches when indexing to SAP Cloud Logging.
-However, if you want to retain the original type of your custom fields you can change the type conversion configuration accordingly:
+However, if you want to retain the original type of your custom fields, you can change the type conversion configuration accordingly:
 
 ```js
 log.setCustomFieldsTypeConversion(CustomFieldsTypeConversion.Retain)

--- a/src/lib/config/config.ts
+++ b/src/lib/config/config.ts
@@ -7,7 +7,7 @@ import coreConfig from './default/config-core.json';
 import kymaConfig from './default/config-kyma.json';
 import requestConfig from './default/config-request.json';
 import sapPassportConfig from './default/config-sap-passport.json';
-import { ConfigField, ConfigObject, CustomFieldsFormat, Framework, Output, Source, SourceType } from './interfaces';
+import { ConfigField, ConfigObject, CustomFieldsFormat, CustomFieldsTypeConversion, Framework, Output, Source, SourceType } from './interfaces';
 
 export default class Config {
 
@@ -63,6 +63,7 @@ export default class Config {
                 Config.instance.setCustomFieldsFormat(CustomFieldsFormat.CloudLogging);
             }
 
+            Config.instance.setCustomFieldsTypeConversion(CustomFieldsTypeConversion.Stringify)
             Config.instance.addConfig(configFiles);
         }
 
@@ -213,6 +214,10 @@ export default class Config {
                 Config.instance.config.customFieldsFormat = file.customFieldsFormat;
             }
 
+            if (file.customFieldsTypeConversion) {
+                Config.instance.config.customFieldsTypeConversion = file.customFieldsTypeConversion;
+            }
+
             if (file.framework) {
                 Config.instance.config.framework = file.framework;
             }
@@ -231,6 +236,10 @@ export default class Config {
 
     setCustomFieldsFormat(format: CustomFieldsFormat) {
         Config.instance.config.customFieldsFormat = format;
+    }
+
+    setCustomFieldsTypeConversion(conversion: CustomFieldsTypeConversion) {
+        Config.instance.config.customFieldsTypeConversion = conversion;
     }
 
     setStartupMessageEnabled(enabled: boolean) {

--- a/src/lib/config/default/config-schema.json
+++ b/src/lib/config/default/config-schema.json
@@ -105,6 +105,13 @@
             ],
             "type": "string"
         },
+        "CustomFieldsTypeConversion": {
+            "enum": [
+                "retain",
+                "stringify"
+            ],
+            "type": "string"
+        },
         "DetailName": {
             "enum": [
                 "level",
@@ -192,6 +199,9 @@
     "properties": {
         "customFieldsFormat": {
             "$ref": "#/definitions/CustomFieldsFormat"
+        },
+        "customFieldsTypeConversion": {
+            "$ref": "#/definitions/CustomFieldsTypeConversion"
         },
         "fields": {
             "items": {

--- a/src/lib/config/interfaces.ts
+++ b/src/lib/config/interfaces.ts
@@ -1,6 +1,7 @@
 export interface ConfigObject {
     fields?: ConfigField[];
     customFieldsFormat?: CustomFieldsFormat;
+    customFieldsTypeConversion?: CustomFieldsTypeConversion;
     outputStartupMsg?: boolean;
     reqLoggingLevel?: string;
     framework?: Framework;
@@ -58,6 +59,11 @@ export enum CustomFieldsFormat {
     All = "all",
     Disabled = "disabled",
     Default = "default"
+}
+
+export enum CustomFieldsTypeConversion {
+    Retain = "retain",
+    Stringify = "stringify"
 }
 
 export enum SourceType {

--- a/src/lib/logger/recordFactory.ts
+++ b/src/lib/logger/recordFactory.ts
@@ -2,7 +2,7 @@ import jsonStringifySafe from 'json-stringify-safe';
 import util from 'util';
 
 import Config from '../config/config';
-import { CustomFieldsFormat, Output } from '../config/interfaces';
+import { CustomFieldsFormat, CustomFieldsTypeConversion, Output } from '../config/interfaces';
 import StacktraceUtils from '../helper/stacktraceUtils';
 import { isValidObject } from '../middleware/utils';
 import Cache from './cache';
@@ -102,6 +102,7 @@ export default class RecordFactory {
         customFieldsFromArgs: Map<string, any> = new Map()) {
         const providedFields = new Map<string, any>([...loggerCustomFields, ...customFieldsFromArgs]);
         const customFieldsFormat = this.config.getConfig().customFieldsFormat!;
+        const customFieldsTypeConversion = this.config.getConfig().customFieldsTypeConversion!;
 
         // if format "disabled", do not log any custom fields
         if (customFieldsFormat == CustomFieldsFormat.Disabled) {
@@ -110,19 +111,23 @@ export default class RecordFactory {
 
         let indexedCustomFields: any = {};
         providedFields.forEach((value, key) => {
-            // Stringify, if necessary.
-            if ((typeof value) != "string") {
-                value = jsonStringifySafe(value);
-            }
-
             if ([CustomFieldsFormat.CloudLogging, CustomFieldsFormat.All, CustomFieldsFormat.Default].includes(customFieldsFormat)
                 || record.payload[key] != null || this.config.isSettable(key)) {
+                // Stringify, if conversion type 'stringify' is selected and value is not a string already.
+                if (customFieldsTypeConversion == CustomFieldsTypeConversion.Stringify && (typeof value) != "string") {
+                    record.payload[key] = jsonStringifySafe(value);;
+                } else {
                     record.payload[key] = value;
-                   
+                }               
             }
 
             if ([CustomFieldsFormat.ApplicationLogging, CustomFieldsFormat.All].includes(customFieldsFormat)) {
-                indexedCustomFields[key] = value;
+                // Stringify, if necessary.
+                if ((typeof value) != "string") {
+                    indexedCustomFields[key] = jsonStringifySafe(value);
+                } else {
+                    indexedCustomFields[key] = value;
+                }
             }
         });
 

--- a/src/lib/logger/recordFactory.ts
+++ b/src/lib/logger/recordFactory.ts
@@ -115,10 +115,10 @@ export default class RecordFactory {
                 || record.payload[key] != null || this.config.isSettable(key)) {
                 // Stringify, if conversion type 'stringify' is selected and value is not a string already.
                 if (customFieldsTypeConversion == CustomFieldsTypeConversion.Stringify && (typeof value) != "string") {
-                    record.payload[key] = jsonStringifySafe(value);;
+                    record.payload[key] = jsonStringifySafe(value);
                 } else {
                     record.payload[key] = value;
-                }               
+                }
             }
 
             if ([CustomFieldsFormat.ApplicationLogging, CustomFieldsFormat.All].includes(customFieldsFormat)) {
@@ -131,7 +131,7 @@ export default class RecordFactory {
             }
         });
 
-        //writes custom fields in the correct order and correlates i to the place in registeredCustomFields
+        // Write custom fields in the correct order and correlates i to the place in registeredCustomFields
         if (Object.keys(indexedCustomFields).length > 0) {
             let res: any = {};
             res.string = [];

--- a/src/lib/logger/rootLogger.ts
+++ b/src/lib/logger/rootLogger.ts
@@ -1,6 +1,6 @@
 import Config from '../config/config';
 import {
-    ConfigObject, CustomFieldsFormat, Framework, Output, SourceType
+    ConfigObject, CustomFieldsFormat, CustomFieldsTypeConversion, Framework, Output, SourceType
 } from '../config/interfaces';
 import EnvService from '../helper/envService';
 import Middleware from '../middleware/middleware';
@@ -46,6 +46,10 @@ export default class RootLogger extends Logger {
 
     setCustomFieldsFormat(format: CustomFieldsFormat) {
         return this.config.setCustomFieldsFormat(format);
+    }
+
+    setCustomFieldsTypeConversion(conversion: CustomFieldsTypeConversion) {
+        return this.config.setCustomFieldsTypeConversion(conversion);
     }
 
     setStartupMessageEnabled(enabled: boolean) {

--- a/src/test/acceptance-test/custom-fields.test.js
+++ b/src/test/acceptance-test/custom-fields.test.js
@@ -145,7 +145,7 @@ describe('Test custom fields', function () {
                 log.logMessage("info", "test-message");
             });
 
-            it('logs custom fields as strings', function () {
+            it('logs custom fields with their retained type', function () {
                 expect(lastOutput).to.have.property('field-a', 42).that.is.a('number');
                 expect(lastOutput).to.have.property('field-b', true).that.is.a('boolean');
                 expect(lastOutput).to.have.property('field-c').that.deep.equals({"key":"value"})

--- a/src/test/acceptance-test/custom-fields.test.js
+++ b/src/test/acceptance-test/custom-fields.test.js
@@ -122,6 +122,37 @@ describe('Test custom fields', function () {
         });
     });
 
+    describe('Test custom field type conversion', function () {
+        describe('stringify fields', function () {
+            beforeEach(function () {
+                log = importFresh("../../../build/main/index");
+                log.setCustomFields({ "field-a": 42, "field-b": true, "field-c": { "key": "value" }});
+                log.logMessage("info", "test-message");
+            });
+
+            it('logs custom fields as strings', function () {
+                expect(lastOutput).to.have.property('field-a', '42').that.is.a('string');
+                expect(lastOutput).to.have.property('field-b', 'true').that.is.a('string');
+                expect(lastOutput).to.have.property('field-c', '{"key":"value"}').that.is.a('string');
+            });
+        });
+
+        describe('retain field types', function () {
+            beforeEach(function () {
+                log = importFresh("../../../build/main/index");
+                log.setCustomFieldsTypeConversion("retain");
+                log.setCustomFields({ "field-a": 42, "field-b": true, "field-c": { "key": "value" }});
+                log.logMessage("info", "test-message");
+            });
+
+            it('logs custom fields as strings', function () {
+                expect(lastOutput).to.have.property('field-a', 42).that.is.a('number');
+                expect(lastOutput).to.have.property('field-b', true).that.is.a('boolean');
+                expect(lastOutput).to.have.property('field-c').that.deep.equals({"key":"value"})
+            });
+        });
+    })
+
     describe('Test custom field format', function () {
         describe('"cloud-logging" format', function () {
             beforeEach(function () {

--- a/src/test/acceptance-test/request-context.test.js
+++ b/src/test/acceptance-test/request-context.test.js
@@ -37,7 +37,7 @@ describe('Test request context', function () {
                     .get("/requestcontext")
                     .set({ "x-vcap-request-id": "1234", "tenantid": "1234" })
                     .expect(200)
-                    .then(done())
+                    .then(() => done())
                     .catch(err => done(err));
             });
 
@@ -92,7 +92,7 @@ describe('Test request context', function () {
                 supertest(expressApp)
                     .get("/setloglevel")
                     .expect(200)
-                    .then(done())
+                    .then(() => done())
                     .catch(err => done(err));
 
             });
@@ -111,7 +111,7 @@ describe('Test request context', function () {
                 supertest(expressApp)
                     .get("/setcorrelationandtenantid")
                     .expect(200)
-                    .then(done())
+                    .then(() => done())
                     .catch(err => done(err));
             });
 
@@ -143,7 +143,7 @@ describe('Test request context', function () {
                     .set("x-correlationid", correlation_id)
                     .set("tenantid", tenant_id)
                     .expect(200)
-                    .then(done())
+                    .then(() => done())
                     .catch(err => done(err));
             });
 
@@ -166,7 +166,7 @@ describe('Test request context', function () {
                 supertest(expressApp)
                     .get("/getcorrelationandtenantid")
                     .expect(200)
-                    .then(done())
+                    .then(() => done())
                     .catch(err => done(err));
             });
 
@@ -186,7 +186,7 @@ describe('Test request context', function () {
                 supertest(expressApp)
                     .get("/requestcontext")
                     .expect(200)
-                    .then(done())
+                    .then(() => done())
                     .catch(err => done(err));
             });
 
@@ -234,9 +234,7 @@ describe('Test request context', function () {
                         .get("/requestcontext")
                         .set('SAP-LOG-LEVEL', 'eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJsZXZlbCI6ImVycm9yIiwiZXhwIjoxNzgyOTgxNzg4LCJpc3N1ZXIiOiJpc3N1ZXJAc2FwLmNvbSIsImlhdCI6MTY1MzM4MTc4OH0.t3sHQMc5M8fch_U8WBFCCDyKS3D-1bj6hhft6MB1puXXHnzyTSQDz8oAbgkCpSiUOxRzE3GpRiMpMZEFCm4cvl2xy2TCxERzBBTQBxON_Au7_ggzJUtxrGkuurxWBMf7hjWWxMP2p3DkJvVD8gpM4VphJKwIto0WDJIcdqTtkFM4wruPAEn-nNlyAZCp3GYOcYMtqv3dz1ShckB8uF6KCs_dv238DMI_6q0Y9HtXW_o4gParTL20vDB9IIibpJ3JsKJu2LlZJ6dSkR0iAwqXSTjiXGpMIz3P82URKekTGABxumqHE1Jgl3Kdlquu5r6OvEgwqeMh8oui2ZofLiVe-Q')
                         .expect(200)
-                        .then(
-                            done()
-                        )
+                        .then(() => done())
                         .catch(err => done(err));
                 });
 
@@ -251,9 +249,7 @@ describe('Test request context', function () {
                         .get("/requestcontext")
                         .set('SAP-LOG-LEVEL', 'eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJsZXZlbCI6ImRlYnVnIiwiZXhwIjoxNzgyOTgyMDk0LCJpc3N1ZXIiOiJpc3N1ZXJAc2FwLmNvbSIsImlhdCI6MTY1MzM4MjA5NH0.c2TsfootLMbGNKoLmsaffINnyE-Vd-UQuOMvDLaQnkFdlSlp67fl327XL2Ttsc_JDse-YROqWcSMucohrLtcabE8MTcVTq_VeIIG_nGQ9WqKsDg1XXzJvFi5VdFAMcHdSgBnrcDSarRNn2kA6Hjcx7sT8aCCrHQRdtGyUVr4t20AHNpwTapKZvrfI7MjtQYDr4KywjoCojRklaUWSvoDn-iLIoZ-kbJLmQyxK5lvpjhvw-Ip8jRQAheyq04wp6CW0mMzWkvqdMIWciUQ_hh2RBg84s1An-kXIKq5Yju0zsDLQ8UPmJWfcNUZ4ACsaZO2WA3xytD4kY6KF_fpZVgVcA')
                         .expect(200)
-                        .then(
-                            done()
-                        )
+                        .then(() => done())
                         .catch(err => done(err));
                 });
 
@@ -285,7 +281,7 @@ describe('Test request context', function () {
                     .set("x-correlationid", correlation_id)
                     .set("tenantid", tenant_id)
                     .expect(200)
-                    .then(done())
+                    .then(() => done())
                     .catch(err => done(err));
             });
 
@@ -312,7 +308,7 @@ describe('Test request context', function () {
                 supertest(restifyApp)
                     .get("/setcorrelationandtenantid")
                     .expect(200)
-                    .then(done())
+                    .then(() => done())
                     .catch(err => done(err));
             });
 
@@ -336,7 +332,7 @@ describe('Test request context', function () {
                 supertest(restifyApp)
                     .get("/getcorrelationandtenantid")
                     .expect(200)
-                    .then(done())
+                    .then(() => done())
                     .catch(err => done(err));
             });
 
@@ -368,7 +364,7 @@ describe('Test request context', function () {
                     .set("x-correlationid", correlation_id)
                     .set("tenantid", tenant_id)
                     .expect(200)
-                    .then(done())
+                    .then(() => done())
                     .catch(err => done(err));
             });
 
@@ -395,7 +391,7 @@ describe('Test request context', function () {
                 supertest(connectApp)
                     .get("/setcorrelationandtenantid")
                     .expect(200)
-                    .then(done())
+                    .then(() => done())
                     .catch(err => done(err));
             });
 
@@ -419,7 +415,7 @@ describe('Test request context', function () {
                 supertest(connectApp)
                     .get("/getcorrelationandtenantid")
                     .expect(200)
-                    .then(done())
+                    .then(() => done())
                     .catch(err => done(err));
             });
 
@@ -452,7 +448,7 @@ describe('Test request context', function () {
                         .set("x-correlationid", correlation_id)
                         .set("tenantid", tenant_id)
                         .expect(200)
-                        .then(done())
+                        .then(() => done())
                         .catch(err => done(err));
                 })
             });
@@ -480,7 +476,7 @@ describe('Test request context', function () {
                     supertest(fastifyApp.server)
                         .get("/setcorrelationandtenantid")
                         .expect(200)
-                        .then(done())
+                        .then(() => done())
                         .catch(err => done(err));
                 })
             });
@@ -505,7 +501,7 @@ describe('Test request context', function () {
                     supertest(fastifyApp.server)
                         .get("/getcorrelationandtenantid")
                         .expect(200)
-                        .then(done())
+                        .then(() => done())
                         .catch(err => done(err));
                 })
             });
@@ -538,7 +534,7 @@ describe('Test request context', function () {
                     .set("x-correlationid", correlation_id)
                     .set("tenantid", tenant_id)
                     .expect(200)
-                    .then(done())
+                    .then(() => done())
                     .catch(err => done(err));
             });
 
@@ -564,7 +560,7 @@ describe('Test request context', function () {
                 supertest(httpApp)
                     .get("/setcorrelationandtenantid")
                     .expect(200)
-                    .then(done())
+                    .then(() => done())
                     .catch(err => done(err));
             });
 
@@ -588,7 +584,7 @@ describe('Test request context', function () {
                 supertest(httpApp)
                     .get("/testget")
                     .expect(200)
-                    .then(done())
+                    .then(() => done())
                     .catch(err => done(err));
             });
 

--- a/src/test/unit-test/config.test.js
+++ b/src/test/unit-test/config.test.js
@@ -100,6 +100,20 @@ describe('Test Config class', function () {
         })
     });
 
+    describe('Test setCustomFieldsTypeConversion', function () {
+        beforeEach(function () {
+            singleton.setCustomFieldsTypeConversion("retain");
+            result = singleton.getConfig();
+        });
+        it('sets custom fields format', function () {
+            expect(result).to.have.property("customFieldsTypeConversion", "retain");
+        });
+
+        afterEach(function () {
+            singleton.setCustomFieldsFormat("stringify");
+        })
+    });
+
     describe('Test setStartupMessageEnabled', function () {
         beforeEach(function () {
             singleton.setStartupMessageEnabled(false);


### PR DESCRIPTION
- Add setting to retain custom field types when using cloud logging format
- Update documentation accordingly
- Fix test cases failing due to async callback called too early