### PR TITLE
Fix quotation error

### DIFF
--- a/docs/general-usage/04-custom-fields.md
+++ b/docs/general-usage/04-custom-fields.md
@@ -36,7 +36,7 @@ Custom fields are converted and printed as string values independent of their or
 log.registerCustomFields(["field"]);
 info("Test data", {"field": 42}); 
 // ... "msg":"Test data" 
-// ... "#cf": {"string": [{"k":"field","v":"42","i":"0"}]}...
+// ... "#cf": {"string": [{"k":"field","v":"42","i":0}]}...
 ```
 
 ### SAP Cloud Logging


### PR DESCRIPTION
The documentation does not reflect what the code really does.
The index i needs to be a number, not a string.
The code is working correctly.