### PR TITLE
Replace UUID dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cf-nodejs-logging-support",
-  "version": "7.4.5",
+  "version": "7.4.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "cf-nodejs-logging-support",
-      "version": "7.4.5",
+      "version": "7.4.6",
       "license": "Apache-2.0",
       "dependencies": {
         "ajv": "^8.18.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,14 +13,12 @@
         "json-stringify-safe": "^5.0.1",
         "jsonwebtoken": "^9.0.3",
         "triple-beam": "^1.3.0",
-        "uuid": "^9.0.0",
         "winston-transport": "^4.5.0"
       },
       "devDependencies": {
         "@types/json-stringify-safe": "^5.0.0",
         "@types/node": "^17.0.45",
         "@types/triple-beam": "^1.3.2",
-        "@types/uuid": "^9.0.1",
         "@typescript-eslint/eslint-plugin": "^5.42.1",
         "@typescript-eslint/parser": "^5.42.1",
         "chai": "^4.3.6",
@@ -1148,12 +1146,6 @@
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/@types/triple-beam/-/triple-beam-1.3.5.tgz",
       "integrity": "sha512-6WaYesThRMCl19iryMYP7/x2OVgCtbIVflDGFpWnb9irXI3UjYE4AzmYuiUKY1AJstGijoY+MgUszMgRxIYTYw=="
-    },
-    "node_modules/@types/uuid": {
-      "version": "9.0.8",
-      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-9.0.8.tgz",
-      "integrity": "sha512-jg+97EGIcY9AGHJJRaaPVgetKDsrTgbRjQ5Msgjh/DQKEFl0DtyRr/VCOyD1T2R1MNeWPK/u7JoGhlDZnKBAfA==",
-      "dev": true
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "5.62.0",
@@ -8122,6 +8114,7 @@
       "version": "9.0.1",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
       "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "dev": true,
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
@@ -9305,12 +9298,6 @@
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/@types/triple-beam/-/triple-beam-1.3.5.tgz",
       "integrity": "sha512-6WaYesThRMCl19iryMYP7/x2OVgCtbIVflDGFpWnb9irXI3UjYE4AzmYuiUKY1AJstGijoY+MgUszMgRxIYTYw=="
-    },
-    "@types/uuid": {
-      "version": "9.0.8",
-      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-9.0.8.tgz",
-      "integrity": "sha512-jg+97EGIcY9AGHJJRaaPVgetKDsrTgbRjQ5Msgjh/DQKEFl0DtyRr/VCOyD1T2R1MNeWPK/u7JoGhlDZnKBAfA==",
-      "dev": true
     },
     "@typescript-eslint/eslint-plugin": {
       "version": "5.62.0",
@@ -14489,7 +14476,8 @@
     "uuid": {
       "version": "9.0.1",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA=="
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "dev": true
     },
     "v8-compile-cache": {
       "version": "2.4.0",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
     "@types/json-stringify-safe": "^5.0.0",
     "@types/node": "^17.0.45",
     "@types/triple-beam": "^1.3.2",
-    "@types/uuid": "^9.0.1",
     "@typescript-eslint/eslint-plugin": "^5.42.1",
     "@typescript-eslint/parser": "^5.42.1",
     "chai": "^4.3.6",
@@ -66,7 +65,6 @@
     "json-stringify-safe": "^5.0.1",
     "jsonwebtoken": "^9.0.3",
     "triple-beam": "^1.3.0",
-    "uuid": "^9.0.0",
     "winston-transport": "^4.5.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cf-nodejs-logging-support",
-  "version": "7.4.5",
+  "version": "7.4.6",
   "description": "Logging tool for Cloud Foundry",
   "keywords": [
     "logging",

--- a/src/lib/logger/sourceUtils.ts
+++ b/src/lib/logger/sourceUtils.ts
@@ -1,4 +1,4 @@
-import { v4 as uuid } from 'uuid';
+import { randomUUID } from 'crypto';
 
 import Config from '../config/config';
 import { ConfigField, Conversion, DetailName, Output, Source, SourceType } from '../config/interfaces';
@@ -110,7 +110,7 @@ export default class SourceUtils {
                 value = this.getDetail(source.detailName!, record, req, res)
                 break;
             case SourceType.UUID:
-                value = uuid();
+                value = randomUUID();
                 break;
         }
 


### PR DESCRIPTION
Updating UUID to 14.0.0 would require breaking changes and new major version release. By replacing this dependency with `randomUUID` from `crypto` package we can avoid a forced release of v8.

Update version for 7.4.6 release.