### PR TITLE
Bump fast-uri transitive dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1450,9 +1450,9 @@
       }
     },
     "node_modules/ajv/node_modules/fast-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
       "funding": [
         {
           "type": "github",
@@ -9470,9 +9470,9 @@
       },
       "dependencies": {
         "fast-uri": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-          "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA=="
+          "version": "3.1.2",
+          "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+          "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ=="
         }
       }
     },


### PR DESCRIPTION
- Update fast-uri transitive dependency to version [3.1.2](https://github.com/fastify/fast-uri/releases/tag/v3.1.2)