### PR TITLE
Fix broken links and remove legacy sample app from docs

### DIFF
--- a/docs/sample-apps/index.md
+++ b/docs/sample-apps/index.md
@@ -7,16 +7,11 @@ has_children: true
 
 # Sample Apps
 
-## cf-nodejs-sample-app
+## cf-nodejs-logging-support-sample
 
-To get a better understanding of how this library can be used to write request and message logs in actual Node.js applications take a look at our [cf-node-sample-app](https://github.com/SAP/cf-nodejs-logging-support/tree/master/sample/cf-nodejs-logging-support-sample).
-The application shows buttons to test different features and can be deployed on Cloud Foundry. 
-
-## cf-nodejs-shoutboard
-
-To get a better understanding of how this library can be used to write request and message logs in actual Node.js applications take a look at our [cf-node-shoutboard](https://github.com/SAP/cf-nodejs-logging-support/tree/master/sample/cf-nodejs-shoutboard). 
-The application hosts a simple shoutboard and can be deployed on Cloud Foundry. 
+The [cf-nodejs-logging-support-sample](https://github.com/SAP/cf-nodejs-logging-support/tree/main/sample/cf-nodejs-logging-support-sample) app demonstrates how to use this library for request and message logging in a Node.js application.
+It provides an interactive UI for testing different features and can be deployed to Cloud Foundry.
 
 ## winston-sample
 
-Have a look at our minimal [winston-sample](https://github.com/SAP/cf-nodejs-logging-support/tree/master/sample/winston-sample) application to learn how to use our Winston transport.
+The [winston-sample](https://github.com/SAP/cf-nodejs-logging-support/tree/main/sample/winston-sample) app is a minimal application showing how to integrate our Winston transport.


### PR DESCRIPTION
Update docs:
- Fix broken sample app links
- Remove legacy sample app section